### PR TITLE
관리자 게시판 삭제 api 구현

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/board/controller/AdminBoardController.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/controller/AdminBoardController.java
@@ -61,5 +61,12 @@ public class AdminBoardController {
         ));
     }
 
-
+    // 게시판 삭제, id만 받아서 삭제
+    @DeleteMapping("/{boardId}")
+    ResponseEntity<ApiResponse> deleteBoard(
+            @PathVariable Long boardId
+    ){
+        boardService.deleteBoard(boardId);
+        return ResponseEntity.ok(ApiResponse.ofSuccessWithoutBody());
+    }
 }

--- a/backend/src/main/java/com/team01/backend/domain/board/service/BoardService.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/service/BoardService.java
@@ -46,4 +46,11 @@ public class BoardService {
     public long count() {
         return boardRepository.count();
     }
+
+    // 게시판 삭제
+    @Transactional
+    public void deleteBoard(Long id) {
+        Board board = boardRepository.findById(id).orElseThrow(EntityNotFoundException::new); // 없는 id 예외 처리
+        boardRepository.delete(board);
+    }
 }

--- a/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
+++ b/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
@@ -1,0 +1,40 @@
+package com.team01.backend.global.initData;
+
+import com.team01.backend.domain.board.service.BoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.transaction.annotation.Transactional;
+
+@Configuration
+@RequiredArgsConstructor
+public class BaseInitData {
+
+    @Autowired
+    @Lazy
+    private BaseInitData self;
+    @Autowired
+    private BoardService boardService;
+
+    @Bean
+    public ApplicationRunner initData() {
+        return args -> {
+            self.setBoard();
+        };
+    }
+
+    // 게시판 생성
+    @Transactional
+    public void setBoard(){
+        if(boardService.count() > 0){
+            return;
+        }
+        boardService.createBoard("name1", "description1");
+        boardService.createBoard("name2", "description2");
+        boardService.createBoard("name3", "description3");
+    }
+
+}

--- a/backend/src/test/java/com/team01/backend/domain/board/controller/AdminBoardControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/board/controller/AdminBoardControllerTest.java
@@ -12,8 +12,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.hamcrest.Matchers.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -175,4 +174,41 @@ public class AdminBoardControllerTest {
                 .andExpect(jsonPath("$.code").value("NOT_FOUND"))
                 .andExpect(jsonPath("$.message",startsWith("요청하신 데이터를 찾을 수 없습니다.")));
     }
+
+    @Test
+    @DisplayName("게시판 삭제 테스트")
+    void d1() throws Exception{
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/api/v1/admin/board/3")
+                )
+                .andDo(print());
+        resultActions.andExpect(handler().handlerType(AdminBoardController.class))
+                .andExpect(handler().methodName("deleteBoard"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+    @Test
+    @DisplayName("게시판 삭제 테스트 - 없는 id")
+    void d2() throws Exception{
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/api/v1/admin/board/6")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "name":"name6",
+                                            "description":"description 6"
+                                        }
+                                        """)
+                )
+                .andDo(print());
+        resultActions.andExpect(handler().handlerType(AdminBoardController.class))
+                .andExpect(handler().methodName("deleteBoard"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.message",startsWith("요청하신 데이터를 찾을 수 없습니다.")));
+    }
+
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
> 관리자 게시판 삭제 기능
>
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
> @PathVariable로 id 받아와서 삭제
> 예외 처리 : 존재하지 않는 게시판 id 예외 처리
> 삭제 후 ofSuccessWithoutBody() 로 반환 
> Postman으로 확인한 결과 첨부합니다
> 
> **[삭제 전 다건 조회]**
> <img width="554" height="393" alt="image" src="https://github.com/user-attachments/assets/5740159f-d1ff-46ec-9b47-9e11384197c0" />
> 
> **[삭제 후 다건조회]**
> <img width="537" height="381" alt="image" src="https://github.com/user-attachments/assets/60de2a40-4995-4b79-8590-62667015c079" />


## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
> 삭제시에 삭제한 게시판의 정보를 return하지 않는 방향으로 구현했습니다.
> 삭제시에도 게시판 정보 반환이 필요하다고 생각하시면 의견 주시면 감사하겠습니다!