### PR TITLE
feat: 게시판 별 글 전체 조회(post-01)

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/board/controller/BoardController.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/controller/BoardController.java
@@ -2,6 +2,8 @@ package com.team01.backend.domain.board.controller;
 
 import com.team01.backend.domain.board.dto.BoardResponse;
 import com.team01.backend.domain.board.service.BoardService;
+import com.team01.backend.domain.post.dto.PostDto;
+import com.team01.backend.domain.post.service.PostService;
 import com.team01.backend.global.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -12,7 +14,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/board")
+@RequestMapping("/boards")
 @RequiredArgsConstructor
 public class BoardController {
     private final BoardService boardService;

--- a/backend/src/main/java/com/team01/backend/domain/board/controller/BoardController.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/controller/BoardController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.List;
 
 @RestController
-@RequestMapping("/boards")
+@RequestMapping("/board")
 @RequiredArgsConstructor
 public class BoardController {
     private final BoardService boardService;

--- a/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
@@ -1,0 +1,28 @@
+package com.team01.backend.domain.post.controller;
+
+
+import com.team01.backend.domain.post.dto.PostResponseDto;
+import com.team01.backend.domain.post.service.PostService;
+import com.team01.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+    private final PostService postService;
+
+    // 게시판별 글 목록 조회
+    @GetMapping("/boards/{boardId}/posts")
+    public ResponseEntity<ApiResponse<List<PostResponseDto>>> getPostsByBoardId(
+            @PathVariable Long boardId
+    ) {
+        List<PostResponseDto> posts = postService.getPostsByBoardId(boardId);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(posts));
+    }
+}

--- a/backend/src/main/java/com/team01/backend/domain/post/dto/PostResponseDto.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/dto/PostResponseDto.java
@@ -1,0 +1,21 @@
+package com.team01.backend.domain.post.dto;
+
+import com.team01.backend.domain.post.entity.Post;
+
+import java.time.LocalDateTime;
+
+public record PostResponseDto(
+        Long id,
+        String title,
+        int likeCount,
+        LocalDateTime createdAt
+) {
+    public PostResponseDto(Post post) {
+        this(
+                post.getId(),
+                post.getTitle(),
+                post.getLikeCount(),
+                post.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepository.java
@@ -3,6 +3,10 @@ package com.team01.backend.domain.post.repository;
 import com.team01.backend.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+    // 게시판별 글 전체 조회 (삭제되지 않은 글만)
+    List<Post> findByBoardIdAndIsDeletedFalse(Long boardId);
 
 }

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -1,9 +1,12 @@
 package com.team01.backend.domain.post.service;
 
+import com.team01.backend.domain.post.dto.PostResponseDto;
 import com.team01.backend.domain.post.entity.Post;
 import com.team01.backend.domain.post.repository.PostRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -25,6 +28,13 @@ public class PostService {
 
     public long count() {
         return postRepository.count();
+    }
+
+    public List<PostResponseDto> getPostsByBoardId(Long boardId) {
+        return postRepository.findByBoardIdAndIsDeletedFalse(boardId)
+                .stream()
+                .map(PostResponseDto::new)
+                .toList();
     }
 
 }

--- a/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
+++ b/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
@@ -1,6 +1,7 @@
 package com.team01.backend.global.initData;
 
 import com.team01.backend.domain.board.service.BoardService;
+import com.team01.backend.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.ApplicationRunner;
@@ -18,11 +19,14 @@ public class BaseInitData {
     private BaseInitData self;
     @Autowired
     private BoardService boardService;
+    @Autowired
+    private PostService postService;
 
     @Bean
     public ApplicationRunner initData() {
         return args -> {
             self.setBoard();
+            self.setPost();
         };
     }
 
@@ -37,4 +41,15 @@ public class BaseInitData {
         boardService.createBoard("name3", "description3");
     }
 
+    // 게시글 생성
+    @Transactional
+    public void setPost(){
+        if(postService.count() > 0){
+            return;
+        }
+        // 1번 게시판에 글 3개
+        postService.write("게시글 1", "내용 1");
+        postService.write("게시글 2", "내용 2");
+        postService.write("게시글 3", "내용 3");
+    }
 }

--- a/backend/src/test/java/com/team01/backend/domain/board/controller/BoardControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/board/controller/BoardControllerTest.java
@@ -44,9 +44,9 @@ public class BoardControllerTest {
     }
 
     @Test
-    @DisplayName("게시판 목록 조회 - 빈 배열 반환")
+    @DisplayName("게시판 목록 조회 - 초기 데이터 반환")
     void t2() throws Exception {
-        // given: DB에 게시판 없음
+        // given: BaseInitData에 의해 기본 게시판 3개가 생성됨
 
         // when
         ResultActions resultActions = mvc
@@ -60,6 +60,6 @@ public class BoardControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data").isEmpty());
+                .andExpect(jsonPath("$.data.length()").value(3));
     }
 }

--- a/backend/src/test/java/com/team01/backend/domain/board/controller/BoardControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/board/controller/BoardControllerTest.java
@@ -31,7 +31,7 @@ public class BoardControllerTest {
 
         // when
         ResultActions resultActions = mvc
-                .perform(get("/board"))
+                .perform(get("/boards"))
                 .andDo(print());
 
         // then
@@ -50,7 +50,7 @@ public class BoardControllerTest {
 
         // when
         ResultActions resultActions = mvc
-                .perform(get("/board"))
+                .perform(get("/boards"))
                 .andDo(print());
 
         // then

--- a/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
@@ -1,0 +1,58 @@
+package com.team01.backend.domain.post.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+public class PostControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    @DisplayName("게시판별 글 목록 조회 - 성공")
+    void t1() throws Exception {
+        // given: BaseInitData에서 생성된 데이터 사용
+
+        // when
+        ResultActions resultActions = mvc
+                .perform(get("/boards/1/posts"))
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(handler().handlerType(PostController.class))
+                .andExpect(handler().methodName("getPostsByBoardId"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray());
+    }
+
+    @Test
+    @DisplayName("게시판별 글 목록 조회 - 빈 배열")
+    void t2() throws Exception {
+        // when
+        ResultActions resultActions = mvc
+                .perform(get("/boards/999/posts"))
+                .andDo(print());
+
+        // then
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+}


### PR DESCRIPTION
## 📌 과제 설명
- 특정 게시판의 게시글 목록을 조회하는 API를 구현했습니다. (POST-01)
- 사용자가 게시판별로 게시글 목록을 확인할 수 있는 기능입니다.
- close #13 

## 👩‍💻 요구 사항과 구현 내용

### 게시판별 글 목록 조회 기능 구현

- **PostResponse DTO 작성**
  - record 타입으로 작성
  - id, title, likeCount, createdAt 포함
  - content 제외 (목록에서는 제목만 표시)
  
- **PostRepository 수정**
  - `findByBoardIdAndIsDeletedFalse(Long boardId)` 메서드 추가
  - 특정 게시판의 삭제되지 않은 게시글만 조회

- **PostService 수정**
  - `getPostsByBoardId(Long boardId)` 메서드 추가
  - Repository 조회 결과를 PostResponse로 변환하여 반환

- **PostController 작성**
  - GET /boards/{boardId}/posts 엔드포인트 구현
  - ApiResponse 형식으로 응답 래핑

- **PostControllerTest 작성**
  - 게시판별 글 목록 조회 성공 케이스
  - 빈 배열 반환 케이스

- **BaseInitData 수정**
  - 테스트용 게시글 데이터 추가

## ✅ PR 포인트 & 궁금한 점
- PostResponse는 목록 조회용으로 content를 제외하여 응답 크기를 최적화했습니다.
- 삭제된 게시글(isDeleted=true)은 조회 결과에서 제외됩니다.
- 기존 Post 엔티티/Repository를 활용하여 중복 코드를 최소화했습니다.
- ApiResponse 형식을 사용하여 팀 공통 응답 형식을 따랐습니다.