### PR TITLE
feat: 댓글 작성 테스트/ InitData 생성

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/controller/CommentController.java
@@ -15,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
 public class CommentController {
 
     private final CommentService commentService;

--- a/backend/src/main/java/com/team01/backend/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/entity/Comment.java
@@ -47,6 +47,13 @@ public class Comment extends BaseEntity {
         this.parent = parent;
     }
 
+    // 초기 데이터용 생성자 추가
+    public Comment(Post post, String content, Comment parent) {
+        this.post = post;
+        this.content = content;
+        this.parent = parent;  // null이면 일반 댓글, 값 있으면 대댓글
+    }
+
     // 댓글 수정할 때 쓰는 메서드
     public void update(String content) {
         this.content = content;

--- a/backend/src/main/java/com/team01/backend/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/service/CommentService.java
@@ -19,6 +19,29 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final PostRepository postRepository;
 
+    // 댓글 수 조회
+    public long count() {
+        return commentRepository.count();
+    }
+
+    // 초기 데이터용
+    @Transactional
+    public void writeInitComment(Long postId, String content, Long parentId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없어요"));
+
+        // parentId 있으면 부모 댓글 찾기, 없으면 null
+        Comment parent = null;
+        if (parentId != null) {
+            parent = commentRepository.findById(parentId)
+                    .orElseThrow(() -> new EntityNotFoundException("부모 댓글을 찾을 수 없어요"));
+        }
+
+        commentRepository.save(new Comment(post, content, parent));
+    }
+
+    //-----------------------------------------------------------------------------------------------------------------
+
     @Transactional
     public CommentResponseDto writeComment(Long postId, CommentRequestDto reqDto, User loginUser){
 

--- a/backend/src/main/java/com/team01/backend/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/entity/Post.java
@@ -41,6 +41,10 @@ public class Post extends BaseEntity {
 //        this.content = content;
 //    }
 
+//    public void delete() {       Comment테스트
+//        this.isDeleted = true;
+//    }
+
     public Post(String title, String content) {
         this.title = title;
         this.content = content;

--- a/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
+++ b/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
@@ -1,6 +1,7 @@
 package com.team01.backend.global.initData;
 
 import com.team01.backend.domain.board.service.BoardService;
+import com.team01.backend.domain.comment.service.CommentService;
 import com.team01.backend.domain.post.service.PostService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,12 +22,16 @@ public class BaseInitData {
     private BoardService boardService;
     @Autowired
     private PostService postService;
+    @Autowired
+    private CommentService commentService;
+
 
     @Bean
     public ApplicationRunner initData() {
         return args -> {
             self.setBoard();
             self.setPost();
+            self.setComment();
         };
     }
 
@@ -51,5 +56,24 @@ public class BaseInitData {
         postService.write("게시글 1", "내용 1");
         postService.write("게시글 2", "내용 2");
         postService.write("게시글 3", "내용 3");
+    }
+
+    @Transactional
+    public void setComment() {
+        if (commentService.count() > 0) return;
+
+        // 일반 댓글 — parentId 자리에 null
+        commentService.writeInitComment(1L, "첫 번째 댓글입니다", null);
+        commentService.writeInitComment(1L, "두 번째 댓글입니다", null);
+        commentService.writeInitComment(1L, "세 번째 댓글입니다", null);
+
+        // 대댓글 — parentId 자리에 id 값
+        commentService.writeInitComment(1L, "첫 번째 대댓글입니다", 1L);
+        commentService.writeInitComment(1L, "두 번째 대댓글입니다", 2L);
+
+        commentService.writeInitComment(2L, "첫 번째 댓글입니다", null);
+        commentService.writeInitComment(2L, "두 번째 댓글입니다", null);
+
+        commentService.writeInitComment(2L, "첫 번째 대댓글입니다", 6L);
     }
 }

--- a/backend/src/test/java/com/team01/backend/domain/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/comment/controller/CommentControllerTest.java
@@ -32,7 +32,6 @@ public class CommentControllerTest {
     @Autowired
     private MockMvc mvc;
 
-
     @Autowired
     private PostRepository postRepository;
 
@@ -67,7 +66,7 @@ public class CommentControllerTest {
 
         ResultActions resultActions = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
+                        post("/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                     {
@@ -94,7 +93,7 @@ public class CommentControllerTest {
 
         ResultActions resultActions = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
+                        post("/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                     {
@@ -114,13 +113,93 @@ public class CommentControllerTest {
     }
 
     @Test
-    @DisplayName("대댓글 생성 - 1번 댓글에 대댓글 작성")
+    @DisplayName("댓글 작성 실패 - 없는 게시글")
     void t3() throws Exception {
+
+        Long postId = 999L;
+
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/posts/%d/comments".formatted(postId))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                {
+                                    "content": "댓글 내용"
+                                }
+                                """)
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(CommentController.class))
+                .andExpect(handler().methodName("writeComment"))
+                .andExpect(status().isNotFound())               // 404
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("댓글 작성 실패 - 삭제된 게시글")
+    void t4() throws Exception {
+        // 게시글 소프트 딜리트
+        //testPost.delete();
+        postRepository.saveAndFlush(testPost);
+
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/posts/%d/comments".formatted(testPost.getId()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "content": "댓글 내용"
+                                        }
+                                        """)
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(CommentController.class))
+                .andExpect(handler().methodName("writeComment"))
+                .andExpect(status().isBadRequest())             // 400
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    @DisplayName("댓글 작성 실패 - 500자 초과")
+    void t5() throws Exception {
+
+        // 501자 문자열 생성
+        String longContent = "a".repeat(501);
+
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/posts/%d/comments".formatted(testPost.getId()))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                {
+                                    "content": "%s"
+                                }
+                                """.formatted(longContent))
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(CommentController.class))
+                .andExpect(handler().methodName("writeComment"))
+                .andExpect(status().isBadRequest())             // 400
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+    }
+
+    @Test
+    @DisplayName("대댓글 생성 - 1번 댓글에 대댓글 작성")
+    void t6() throws Exception {
 
         // 1. 먼저 부모 댓글 생성
         String createResponse = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
+                        post("/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                 {
@@ -140,7 +219,7 @@ public class CommentControllerTest {
 
         ResultActions resultActions = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
+                        post("/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                 {
@@ -164,12 +243,12 @@ public class CommentControllerTest {
 
     @Test
     @DisplayName("대댓글 생성 실패 - 대댓글에 답글 달기 불가")
-    void t4() throws Exception {
+    void t7() throws Exception {
 
         // 1. 부모 댓글 생성
         String parentResponse = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
+                        post("/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                 {
@@ -186,7 +265,7 @@ public class CommentControllerTest {
         // 2. 대댓글 생성
         String childResponse = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
+                        post("/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                 {
@@ -204,7 +283,7 @@ public class CommentControllerTest {
         // 3. 대댓글의 대댓글 시도 → 실패해야 함
         ResultActions resultActions = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(1))
+                        post("/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                 {
@@ -226,11 +305,11 @@ public class CommentControllerTest {
 
     @Test
     @DisplayName("댓글 수정 - 1번 댓글 수정")
-    void t5() throws Exception {
+    void t8() throws Exception {
 
         ResultActions createResult = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
+                        post("/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                     {
@@ -248,7 +327,7 @@ public class CommentControllerTest {
         String updatedContent = "수정된 댓글";
         ResultActions resultActions = mvc
                 .perform(
-                        put("/api/v1/comments/%d".formatted(commentId))
+                        put("/comments/%d".formatted(commentId))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                     {

--- a/backend/src/test/java/com/team01/backend/domain/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/comment/controller/CommentControllerTest.java
@@ -2,8 +2,6 @@ package com.team01.backend.domain.comment.controller;
 
 
 import com.jayway.jsonpath.JsonPath;
-import com.team01.backend.domain.comment.repository.CommentRepository;
-import com.team01.backend.domain.comment.service.CommentService;
 import com.team01.backend.domain.post.entity.Post;
 import com.team01.backend.domain.post.repository.PostRepository;
 import com.team01.backend.domain.user.entity.User;
@@ -34,8 +32,6 @@ public class CommentControllerTest {
     @Autowired
     private MockMvc mvc;
 
-    @Autowired
-    private CommentService commentService;
 
     @Autowired
     private PostRepository postRepository;
@@ -43,8 +39,6 @@ public class CommentControllerTest {
     @Autowired
     private UserRepository userRepository;
 
-    @Autowired
-    private CommentRepository commentRepository;
 
     private User testUser;
     private Post testPost;
@@ -69,12 +63,11 @@ public class CommentControllerTest {
     @DisplayName("댓글 생성 - 1번 글에 생성")
     void t1() throws Exception {
 
-        int targetPostId = 1;
         String content = "새로운 댓글";
 
         ResultActions resultActions = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(targetPostId))
+                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                     {
@@ -89,7 +82,7 @@ public class CommentControllerTest {
                 .andExpect(handler().methodName("writeComment"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.id").value(1))           // commentDto 제거
+                .andExpect(jsonPath("$.data.id").exists())
                 .andExpect(jsonPath("$.data.content").value(content))
                 .andExpect(jsonPath("$.data.author").value("테스터"))
                 .andExpect(jsonPath("$.data.createdAt").exists());
@@ -99,18 +92,15 @@ public class CommentControllerTest {
     @DisplayName("댓글 생성 - 내용이 없을 시 예외")
     void t2() throws Exception {
 
-        int targetPostId = 1;
-        String content = "";
-
         ResultActions resultActions = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(targetPostId))
+                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                     {
-                                        "content": "%s"
+                                        "content": ""
                                     }
-                                    """.formatted(content))
+                                    """)
                 )
                 .andDo(print());
 
@@ -130,7 +120,7 @@ public class CommentControllerTest {
         // 1. 먼저 부모 댓글 생성
         String createResponse = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(1))
+                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                 {
@@ -150,7 +140,7 @@ public class CommentControllerTest {
 
         ResultActions resultActions = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(1))
+                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                 {
@@ -179,7 +169,7 @@ public class CommentControllerTest {
         // 1. 부모 댓글 생성
         String parentResponse = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(1))
+                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                 {
@@ -196,7 +186,7 @@ public class CommentControllerTest {
         // 2. 대댓글 생성
         String childResponse = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(1))
+                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                 {
@@ -238,11 +228,9 @@ public class CommentControllerTest {
     @DisplayName("댓글 수정 - 1번 댓글 수정")
     void t5() throws Exception {
 
-        // 먼저 댓글 생성
-        int targetPostId = 1;
         ResultActions createResult = mvc
                 .perform(
-                        post("/api/v1/posts/%d/comments".formatted(targetPostId))
+                        post("/api/v1/posts/%d/comments".formatted(testPost.getId()))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                     {


### PR DESCRIPTION
📌 과제 설명
댓글(Comment) 작성 기능 구현 및 초기 데이터 설정을 완료했습니다.

- POST /posts/{postId}/comments — 댓글 및 대댓글 작성
- PUT /comments/{commentId} — 댓글 수정
- BaseInitData — 댓글/대댓글 초기 데이터 추가

feat: BaseInitData 댓글 초기 데이터 추가

setComment() 메서드 추가
- 1번 게시글 댓글 3개, 대댓글 2개 생성
- 2번 게시글 댓글 2개 생성
- parentId null 여부로 일반 댓글/대댓글 구분

test: CommentControllerTest 생성

글작성 예외 테스트
 - 글자수 예외 테스트
 - 없는 게시글
 - 삭제된 게시글