### PR TITLE
feat: COMMENT-02 댓글(답글) 조회

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/controller/CommentController.java
@@ -1,5 +1,6 @@
 package com.team01.backend.domain.comment.controller;
 
+import com.team01.backend.domain.comment.dto.CommentReadResponseDto;
 import com.team01.backend.domain.comment.dto.CommentRequestDto;
 import com.team01.backend.domain.comment.dto.CommentResponseDto;
 import com.team01.backend.domain.comment.service.CommentService;
@@ -13,12 +14,21 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 public class CommentController {
 
     private final CommentService commentService;
     private final UserRepository userRepository;
+
+    // COMMENT-02 댓글(답글) 조회
+    @GetMapping("/posts/{postId}/comments")
+    public ResponseEntity<ApiResponse<List<CommentReadResponseDto>>> getComments(@PathVariable Long postId) {
+        List<CommentReadResponseDto> list = commentService.getCommentsByPostId(postId);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(list));
+    }
 
     @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<ApiResponse<CommentResponseDto>> writeComment(

--- a/backend/src/main/java/com/team01/backend/domain/comment/dto/CommentReadResponseDto.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/dto/CommentReadResponseDto.java
@@ -1,0 +1,47 @@
+package com.team01.backend.domain.comment.dto;
+
+// COMMENT-02 댓글(답글) 조회 — 응답 전용 DTO(작성·수정용 CommentResponseDto와 분리)
+
+import com.team01.backend.domain.comment.entity.Comment;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+public record CommentReadResponseDto(
+        Long id,
+        String content,
+        String author,
+        int likeCount,
+        LocalDateTime createdAt,
+        List<CommentReadResponseDto> replies
+) {
+    // COMMENT-02 댓글(답글) 조회 — 루트 + 답글 엔티티 목록 → 트리 DTO
+    public static CommentReadResponseDto from(Comment root, List<Comment> replyEntities) {
+        List<CommentReadResponseDto> replyDtos = replyEntities.stream()
+                .filter(c -> !c.isDeleted())
+                .sorted(Comparator.comparing(Comment::getCreatedAt))
+                .map(CommentReadResponseDto::fromReply)
+                .toList();
+        return new CommentReadResponseDto(
+                root.getId(),
+                root.getContent(),
+                root.getUser().getNickname(),
+                root.getLikeCount(),
+                root.getCreatedAt(),
+                replyDtos
+        );
+    }
+
+    // COMMENT-02 댓글(답글) 조회 — 답글 1건(하위 replies 없음)
+    private static CommentReadResponseDto fromReply(Comment reply) {
+        return new CommentReadResponseDto(
+                reply.getId(),
+                reply.getContent(),
+                reply.getUser().getNickname(),
+                reply.getLikeCount(),
+                reply.getCreatedAt(),
+                List.of()
+        );
+    }
+}

--- a/backend/src/main/java/com/team01/backend/domain/comment/repository/CommentRepository.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/repository/CommentRepository.java
@@ -1,8 +1,20 @@
 package com.team01.backend.domain.comment.repository;
 
+// COMMENT-02 댓글(답글) 조회 — 아래 선언은 조회 전용(루트·답글 일괄)
+
 import com.team01.backend.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 
+    // COMMENT-02 댓글(답글) 조회 — 게시글별 루트 댓글
+    @EntityGraph(attributePaths = "user")
+    List<Comment> findByPost_IdAndParentIsNullAndIsDeletedFalseOrderByCreatedAtAsc(Long postId);
+
+    // COMMENT-02 댓글(답글) 조회 — 루트 id 목록에 대한 답글 일괄 조회(N+1 방지)
+    @EntityGraph(attributePaths = "user")
+    List<Comment> findByParent_IdInAndIsDeletedFalseOrderByCreatedAtAsc(List<Long> parentIds);
 }

--- a/backend/src/main/java/com/team01/backend/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.team01.backend.domain.comment.service;
 
+import com.team01.backend.domain.comment.dto.CommentReadResponseDto;
 import com.team01.backend.domain.comment.dto.CommentRequestDto;
 import com.team01.backend.domain.comment.dto.CommentResponseDto;
 import com.team01.backend.domain.comment.entity.Comment;
@@ -11,6 +12,11 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -29,6 +35,9 @@ public class CommentService {
     public void writeInitComment(Long postId, User tempUser, String content,  Long parentId) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없어요"));
+        if (post.isDeleted()) {
+            throw new EntityNotFoundException("게시글을 찾을 수 없어요");
+        }
 
         // parentId 있으면 부모 댓글 찾기, 없으면 null
         Comment parent = null;
@@ -41,6 +50,34 @@ public class CommentService {
     }
 
     //-----------------------------------------------------------------------------------------------------------------
+
+    // COMMENT-02 댓글(답글) 조회
+    @Transactional(readOnly = true)
+    public List<CommentReadResponseDto> getCommentsByPostId(Long postId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+        if (post.isDeleted()) {
+            throw new EntityNotFoundException("게시글을 찾을 수 없습니다.");
+        }
+
+        List<Comment> roots = commentRepository
+                .findByPost_IdAndParentIsNullAndIsDeletedFalseOrderByCreatedAtAsc(postId);
+        if (roots.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> rootIds = roots.stream().map(Comment::getId).toList();
+        List<Comment> allReplies =
+                commentRepository.findByParent_IdInAndIsDeletedFalseOrderByCreatedAtAsc(rootIds);
+        Map<Long, List<Comment>> repliesByParentId =
+                allReplies.stream().collect(Collectors.groupingBy(c -> c.getParent().getId()));
+        repliesByParentId.values().forEach(list -> list.sort(Comparator.comparing(Comment::getCreatedAt)));
+
+        return roots.stream()
+                .map(root -> CommentReadResponseDto.from(
+                        root, repliesByParentId.getOrDefault(root.getId(), List.of())))
+                .toList();
+    }
 
     @Transactional
     public CommentResponseDto writeComment(Long postId, CommentRequestDto reqDto, User loginUser){


### PR DESCRIPTION
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- COMMENT-02 댓글(답글) 조회 API 개발
- 게시글 단위 댓글 목록 반환, 각 댓글에 대댓글 목록이 포함된 형태로 응답하도록 구성
- 응답 포맷 -> ApiResponse 래핑 형태로 팀 규칙에 의거

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- Commit 1 - 댓글/답글 조회 API 엔드포인트 추가 (CommentController)
GET /posts/{postId}/comments 엔드포인트를 추가했습니다.
반환 타입을 ApiResponse<List<CommentReadResponseDto>>로 구성했습니다.

- Commit 2 - 조회 전용 DTO 분리 (CommentReadResponseDto)
생성/수정 DTO와 분리된 조회 전용 DTO를 추가했습니다.
루트 댓글 + 답글 구조를 표현할 수 있도록 from(...) 변환 로직을 구성했습니다.

- Commit 3 - Repository 조회 로직 추가 (CommentRepository)
루트 댓글 조회, 답글 일괄 조회(parentId IN) 메서드를 추가했습니다.
조회 시 필요한 연관 데이터 접근을 고려한 메서드 구조로 구성했습니다.

- Commit 4 - 서비스 조회 조립 로직 구현 (CommentService)
게시글 검증 후 루트 댓글 조회 → 답글 일괄 조회 → 부모 기준 그룹핑으로 응답을 조립했습니다.
루트 댓글별 반복 쿼리를 피하도록 구성해 N+1 문제를 완화했습니다.
