### PR TITLE
refactor : 게시판, 카테고리 정보를 객체 형태로 포함(post-02)

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/post/dto/PostDetailResponseDto.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/dto/PostDetailResponseDto.java
@@ -6,11 +6,10 @@ import com.team01.backend.domain.post.entity.Post;
 
 import java.time.LocalDateTime;
 
-// TODO : commit 후에 주석 해제
 public record PostDetailResponseDto(
         Long id,
         BoardInfo board,
-        //CategoryInfo category,
+        CategoryInfo category,
         String title,
         String content,
         int likeCount,
@@ -21,14 +20,13 @@ public record PostDetailResponseDto(
     public record BoardInfo(Long id, String name) {}
 
     // 중첩 record: Category에서 필요한 것만
-    //public record CategoryInfo(Long id, String name) {}
+    public record CategoryInfo(Long id, String name) {}
 
-    // TODO : category 파라미터로 넘겨줘야 함
-    public static PostDetailResponseDto of(Post post, Board board) {
+    public static PostDetailResponseDto of(Post post, Board board, Category category) {
         return new PostDetailResponseDto(
                 post.getId(),
                 new BoardInfo(board.getId(), board.getName()),
-                //new CategoryInfo(category.getId(), category.getName()),
+                new CategoryInfo(category.getId(), category.getName()),
                 post.getTitle(),
                 post.getContent(),
                 post.getLikeCount(),

--- a/backend/src/main/java/com/team01/backend/domain/post/dto/PostDetailResponseDto.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/dto/PostDetailResponseDto.java
@@ -1,23 +1,34 @@
 package com.team01.backend.domain.post.dto;
 
+import com.team01.backend.domain.board.entity.Board;
+import com.team01.backend.domain.category.entity.Category;
 import com.team01.backend.domain.post.entity.Post;
 
 import java.time.LocalDateTime;
 
+// TODO : commit 후에 주석 해제
 public record PostDetailResponseDto(
         Long id,
-        Long boardId,
-        // TODO: categoryId 추가 예정
+        BoardInfo board,
+        //CategoryInfo category,
         String title,
         String content,
         int likeCount,
         LocalDateTime createdAt,
         LocalDateTime modifiedAt
 ) {
-    public PostDetailResponseDto(Post post) {
-        this(
+    // 중첩 record: Board에서 필요한 것만
+    public record BoardInfo(Long id, String name) {}
+
+    // 중첩 record: Category에서 필요한 것만
+    //public record CategoryInfo(Long id, String name) {}
+
+    // TODO : category 파라미터로 넘겨줘야 함
+    public static PostDetailResponseDto of(Post post, Board board) {
+        return new PostDetailResponseDto(
                 post.getId(),
-                post.getBoardId(),
+                new BoardInfo(board.getId(), board.getName()),
+                //new CategoryInfo(category.getId(), category.getName()),
                 post.getTitle(),
                 post.getContent(),
                 post.getLikeCount(),

--- a/backend/src/main/java/com/team01/backend/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/entity/Post.java
@@ -1,7 +1,12 @@
 package com.team01.backend.domain.post.entity;
 
+import com.team01.backend.domain.board.entity.Board;
+import com.team01.backend.domain.category.entity.Category;
 import com.team01.backend.global.entity.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,7 +20,9 @@ public class Post extends BaseEntity {
     private String title;
     private String content;
 
-    private Long boardId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "board_id")
+    private Board board;
 
     // DB에는 authorId 컬럼이 자동으로 생성됨
 //    @ManyToOne(fetch = FetchType.LAZY)
@@ -24,8 +31,8 @@ public class Post extends BaseEntity {
     private int likeCount;
 
     // 그러면 boardId도 사용 가능?
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    private Category category;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category category;
 
     private boolean isDeleted;
 
@@ -61,5 +68,12 @@ public class Post extends BaseEntity {
     public void update(String title, String content) {
         this.title = title;
         this.content = content;
+    }
+
+    public Post(String title, String content, Board board, Category category) {
+        this.title = title;
+        this.content = content;
+        this.board = board;
+        this.category = category;
     }
 }

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 public class PostService {
 
     private final PostRepository postRepository;
-    private final BoardRepository boardRepository;
 
 //    @Transactional
 //    public Post write(User author, String title, String content) {
@@ -53,16 +52,17 @@ public class PostService {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 게시글입니다."));
 
-        Board board = boardRepository.findById(post.getBoardId())
-                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 게시판입니다."));
+        Board board = post.getBoard();
+        if (board == null) {
+            throw new EntityNotFoundException("존재하지 않는 게시판입니다.");
+        }
 
-        // TODO : commit 후에 주석 해제, return에 category 담아야 함
-        //Category category = post.getCategory();
-        //if (category == null) {
-        //    throw new EntityNotFoundException("존재하지 않는 카테고리입니다.");
-        //}
+        Category category = post.getCategory();
+        if (category == null) {
+            throw new EntityNotFoundException("존재하지 않는 카테고리입니다.");
+        }
 
-        return PostDetailResponseDto.of(post, board);
+        return PostDetailResponseDto.of(post, board, category);
     }
 
     public Optional<Post> findById(Long id) {return postRepository.findById(id);}

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -1,9 +1,14 @@
 package com.team01.backend.domain.post.service;
 
+import com.team01.backend.domain.board.entity.Board;
+import com.team01.backend.domain.board.repository.BoardRepository;
+import com.team01.backend.domain.category.entity.Category;
+import com.team01.backend.domain.category.repository.CategoryRepository;
 import com.team01.backend.domain.post.dto.PostDetailResponseDto;
 import com.team01.backend.domain.post.dto.PostResponseDto;
 import com.team01.backend.domain.post.entity.Post;
 import com.team01.backend.domain.post.repository.PostRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +24,7 @@ import java.util.Optional;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final BoardRepository boardRepository;
 
 //    @Transactional
 //    public Post write(User author, String title, String content) {
@@ -45,9 +51,18 @@ public class PostService {
 
     public PostDetailResponseDto getPostById(Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 게시글입니다."));
 
-        return new PostDetailResponseDto(post);
+        Board board = boardRepository.findById(post.getBoardId())
+                .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 게시판입니다."));
+
+        // TODO : commit 후에 주석 해제, return에 category 담아야 함
+        //Category category = post.getCategory();
+        //if (category == null) {
+        //    throw new EntityNotFoundException("존재하지 않는 카테고리입니다.");
+        //}
+
+        return PostDetailResponseDto.of(post, board);
     }
 
     public Optional<Post> findById(Long id) {return postRepository.findById(id);}

--- a/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
+++ b/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
@@ -1,8 +1,12 @@
 package com.team01.backend.global.initData;
 
 import com.team01.backend.domain.board.service.BoardService;
+import com.team01.backend.domain.category.entity.Category;
+import com.team01.backend.domain.category.repository.CategoryRepository;
 import com.team01.backend.domain.category.service.CategoryService;
 import com.team01.backend.domain.comment.service.CommentService;
+import com.team01.backend.domain.post.entity.Post;
+import com.team01.backend.domain.post.repository.PostRepository;
 import com.team01.backend.domain.post.service.PostService;
 import com.team01.backend.domain.user.entity.User;
 import com.team01.backend.domain.user.repository.UserRepository;
@@ -29,6 +33,10 @@ public class BaseInitData {
     private CommentService commentService;
     @Autowired
     private UserRepository userRepository;
+    @Autowired
+    private PostRepository postRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
 
     @Autowired
     private CategoryService categoryService;
@@ -57,13 +65,23 @@ public class BaseInitData {
     // 게시글 생성
     @Transactional
     public void setPost(){
-        if(postService.count() > 0){
-            return;
-        }
-        // 1번 게시판에 글 3개
-        postService.write("게시글 1", "내용 1");
-        postService.write("게시글 2", "내용 2");
-        postService.write("게시글 3", "내용 3");
+        if(postRepository.count() > 0) return;
+
+        // Category 조회
+        Category category = categoryRepository.findById(1L)
+                .orElseThrow(() -> new RuntimeException("Category not found"));
+
+        // TODO : commit 후에 주석 해제
+        // Post 생성 후 설정
+        Post post1 = new Post("게시글 1", "내용 1");
+        //post1.setBoardId(1L);  // ← boardId 설정 필요
+        //post1.setCategory(category);  // ← category 설정 필요
+        postRepository.save(post1);
+
+        Post post2 = new Post("게시글 2", "내용 2");
+        //post2.setBoardId(1L);
+        //post2.setCategory(category);
+        postRepository.save(post2);
     }
 
     @Transactional

--- a/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
+++ b/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
@@ -1,5 +1,7 @@
 package com.team01.backend.global.initData;
 
+import com.team01.backend.domain.board.entity.Board;
+import com.team01.backend.domain.board.repository.BoardRepository;
 import com.team01.backend.domain.board.service.BoardService;
 import com.team01.backend.domain.category.entity.Category;
 import com.team01.backend.domain.category.repository.CategoryRepository;
@@ -37,6 +39,8 @@ public class BaseInitData {
     private PostRepository postRepository;
     @Autowired
     private CategoryRepository categoryRepository;
+    @Autowired
+    private BoardRepository boardRepository;
 
     @Autowired
     private CategoryService categoryService;
@@ -67,21 +71,19 @@ public class BaseInitData {
     public void setPost(){
         if(postRepository.count() > 0) return;
 
-        // Category 조회
+        Board board = boardRepository.findById(1L)
+                .orElseThrow(() -> new RuntimeException("Board not found"));
         Category category = categoryRepository.findById(1L)
                 .orElseThrow(() -> new RuntimeException("Category not found"));
 
-        // TODO : commit 후에 주석 해제
-        // Post 생성 후 설정
-        Post post1 = new Post("게시글 1", "내용 1");
-        //post1.setBoardId(1L);  // ← boardId 설정 필요
-        //post1.setCategory(category);  // ← category 설정 필요
+        Post post1 = new Post("게시글 1", "내용 1", board, category);
         postRepository.save(post1);
 
-        Post post2 = new Post("게시글 2", "내용 2");
-        //post2.setBoardId(1L);
-        //post2.setCategory(category);
+        Post post2 = new Post("게시글 2", "내용 2", board, category);
         postRepository.save(post2);
+
+        Post post3 = new Post("게시글 3", "내용 3", board, category);
+        postRepository.save(post3);
     }
 
     @Transactional


### PR DESCRIPTION
## 📌 과제 설명
- Post Entity의 연관관계를 ID 참조에서 객체 참조로 변경하고, 게시글 상세 조회 응답에 게시판/카테고리 정보를 객체 형태로 포함하도록 개선했습니다.
- **Postman 테스트 한 결과 모두 정상 작동 됐습니다.**
- close #34 

## 👩‍💻 요구 사항과 구현 내용

### Entity 연관관계 변경
- **Post Entity 수정**
  - `private Long boardId` → `@ManyToOne private Board board`
  - `@ManyToOne private Category category` 주석 해제
  - Board, Category를 포함한 생성자 추가

### DTO 구조 개선
- **PostDetailResponseDto 변경**
  - BoardInfo, CategoryInfo 중첩 record 추가 (id, name만 포함)
  - `of()` 정적 팩토리 메서드로 Entity → DTO 변환
  - 필요한 정보만 포함 (Entity 전체 노출 방지)

### Service 로직 개선
- **PostService.getPostById() 수정**
  - BoardRepository 의존성 제거
  - `post.getBoard()`, `post.getCategory()`로 직접 접근
  - null 체크 및 EntityNotFoundException 처리 (404 Not Found)

### 초기 데이터 수정
- **BaseInitData.setPost() 수정**
  - Board, Category 조회 후 생성자로 객체 설정

## ✅ PR 포인트 & 궁금한 점

### 개선 사항
- JPA 연관관계 매핑을 활용하여 객체지향적 설계 적용
- 클라이언트가 추가 API 호출 없이 게시판/카테고리 정보 확인 가능
- DTO에 필요한 정보만 포함하여 불필요한 데이터 노출 방지
- EntityNotFoundException 사용으로 적절한 HTTP 상태 코드 반환 (404)
- setter 대신 생성자 사용으로 Entity 무결성 보호

### 응답 예시
**변경 전**:
```json
{
  "id": 1,
  "boardId": 3,
  "title": "제목",
  "content": "내용"
}
```

**변경 후**:
```json
{
  "id": 1,
  "board": {
    "id": 3,
    "name": "자유게시판"
  },
  "category": {
    "id": 5,
    "name": "일상"
  },
  "title": "제목",
  "content": "내용",
  "likeCount": 0,
  "createdAt": "2026-04-14T12:00:00",
  "modifiedAt": "2026-04-14T12:00:00"
}
```

### 참고
- 회의 결정 사항 반영 (Post Entity에서 boardId 대신 board 객체 사용)
- 코드 리뷰 피드백 반영 (엔티티 자체로서 board 객체로, dto에는 필요한 것만)