### PR TITLE
[feat] 게시글 삭제 api 구현, [refactor] 게시글 등록할 때 board, category 데이터 추가

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
@@ -99,7 +99,7 @@ public class PostController {
     }
 
     // 글 수정 api
-    @PutMapping("posts/{id}")
+    @PutMapping("/posts/{id}")
     public ResponseEntity<ApiResponse<PostModifyResBody>> modify(
             @PathVariable("id") Long id,
             @RequestBody @Valid PostModifyReqBody reqBody

--- a/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
@@ -9,6 +9,7 @@ import com.team01.backend.domain.post.service.PostService;
 import com.team01.backend.global.response.ApiResponse;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -51,7 +52,13 @@ public class PostController {
 
             @Size(min = 2, message = "내용은 2자 이상이어야 합니다.")
             @NotBlank(message = "내용은 공백일 수 없습니다.")
-            String content
+            String content,
+
+            @NotNull(message = "게시판 선택은 필수입니다.")
+            Long boardId,
+
+            @NotNull(message = "카테고리 선택은 필수입니다.")
+            Long categoryId
     ){
     }
 
@@ -69,7 +76,12 @@ public class PostController {
         // User actor = rq.getActor();
 
         //Post post = postService.write(actor, reqBody.title, reqBody.content);
-        Post post = postService.write(reqBody.title, reqBody.content);
+        Post post = postService.write(
+                reqBody.title,
+                reqBody.content,
+                reqBody.boardId,
+                reqBody.categoryId
+        );
 
         long postsCount = postService.count();
 

--- a/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -99,20 +100,20 @@ public class PostController {
     }
 
     // 글 수정 api
-    @PutMapping("/posts/{id}")
+    @PutMapping("/posts/{postId}")
     public ResponseEntity<ApiResponse<PostModifyResBody>> modify(
-            @PathVariable("id") Long id,
+            @PathVariable("postId") Long postId,
             @RequestBody @Valid PostModifyReqBody reqBody
     ) {
         // 유저 정보 생기면 사용
 //        User actor = rq.getActor();
 //
-//        Post post = postService.findById(id).get();
+//        Post post = postService.findById(postId).get();
 //        post.checkModify(actor);
 //
-//        postService.modify(id, reqBody.title, reqBody.content);
+//        postService.modify(postId, reqBody.title, reqBody.content);
 
-        Post post = postService.modify(id, reqBody.title(), reqBody.content());
+        Post post = postService.modify(postId, reqBody.title(), reqBody.content());
 
         return ResponseEntity.ok(
                 ApiResponse.ofSuccess(
@@ -120,6 +121,24 @@ public class PostController {
                                 new PostDto(post)
                         )
                 )
+        );
+    }
+
+    // 글 삭제 api
+    @DeleteMapping("/posts/{postId}")
+    @Transactional
+    public ResponseEntity<ApiResponse<Void>> delete(
+            @PathVariable("postId") Long postId
+    ) {
+        // 유저 인증처리 생기면 사용
+//        User actor = rq.getActor();
+//        postService.delete(postId, actor);
+
+
+        postService.delete(postId);
+
+        return ResponseEntity.ok(
+                ApiResponse.ofSuccess(null)
         );
     }
 }

--- a/backend/src/main/java/com/team01/backend/domain/post/dto/PostDto.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/dto/PostDto.java
@@ -8,8 +8,12 @@ public record PostDto (
     Long id,
     String title,
     String content,
-    //Long authorId,
-    //String authorName,
+    Long boardId,
+    String boardName,
+    Long categoryId,
+    String categoryName,
+//    Long authorId,
+//    String authorName,
     LocalDateTime createdAt,
     LocalDateTime modifiedAt
 ){
@@ -18,8 +22,12 @@ public record PostDto (
                 post.getId(),
                 post.getTitle(),
                 post.getContent(),
-                //post.getAuthor().getId(),
-                //post.getAuthor().getName(),
+                post.getBoard().getId(),
+                post.getBoard().getName(),
+                post.getCategory().getId(),
+                post.getCategory().getName(),
+//                post.getAuthor().getId(),
+//                post.getAuthor().getName(),
                 post.getCreatedAt(),
                 post.getModifiedAt()
         );

--- a/backend/src/main/java/com/team01/backend/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/entity/Post.java
@@ -2,14 +2,16 @@ package com.team01.backend.domain.post.entity;
 
 import com.team01.backend.domain.board.entity.Board;
 import com.team01.backend.domain.category.entity.Category;
+import com.team01.backend.domain.comment.entity.Comment;
+import com.team01.backend.domain.user.entity.User;
 import com.team01.backend.global.entity.BaseEntity;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -25,22 +27,22 @@ public class Post extends BaseEntity {
     private Board board;
 
     // DB에는 authorId 컬럼이 자동으로 생성됨
-//    @ManyToOne(fetch = FetchType.LAZY)
-//    private User author;
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User author;
 
     private int likeCount;
 
-    // 그러면 boardId도 사용 가능?
     @ManyToOne(fetch = FetchType.LAZY)
     private Category category;
 
     private boolean isDeleted = false;
 
-//    @OneToMany(mappedBy = "post",
-//            cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
-//            fetch = FetchType.LAZY,
-//            orphanRemoval = false)  // (소프트 딜리트) : service 에서 delete 로직 짤 때 상태값만 바꾸고, 부모 리스트와의 관계를 끊는 코드를 직접 작성
-//    private List<Comment> comments = new ArrayList<>();
+    @OneToMany(mappedBy = "post",
+            cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
+            fetch = FetchType.LAZY,
+            orphanRemoval = false)  // (소프트 딜리트) : service 에서 delete 로직 짤 때 상태값만 바꾸고, 부모 리스트와의 관계를 끊는 코드를 직접 작성
+    private List<Comment> comments = new ArrayList<>();
+
 
 //    public Post(User author, String title, String content) {
 //        this.author = author;
@@ -48,24 +50,25 @@ public class Post extends BaseEntity {
 //        this.content = content;
 //    }
 
-    //Comment테스트
-    public void delete() {
-        this.isDeleted = true;
-    }
+//    //Comment테스트
+//    public void delete() {
+//        this.isDeleted = true;
+//    }
 
-    public Post(String title, String content) {
-        this.title = title;
-        this.content = content;
-    }
+//    public void delete() {       /*Comment테스트*/
+//        this.isDeleted = true;
+//    }
 
-    public Post(String title, String content, Board board, Category category) {
+
+    public Post(User author, String title, String content, Board board, Category category) {
         this.title = title;
         this.content = content;
         this.board = board;
+        this.author = author;
         this.category = category;
     }
 
-    // 유저 정보 생기면 사용
+    // 유저 인증 로직 생기면 사용
 //    public void checkModify(User actor) {
 //
 //        if (!this.getAuthor().equals(actor)) {

--- a/backend/src/main/java/com/team01/backend/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/entity/Post.java
@@ -34,7 +34,7 @@ public class Post extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Category category;
 
-    private boolean isDeleted;
+    private boolean isDeleted = false;
 
 //    @OneToMany(mappedBy = "post",
 //            cascade = {CascadeType.PERSIST, CascadeType.REMOVE},
@@ -58,6 +58,13 @@ public class Post extends BaseEntity {
         this.content = content;
     }
 
+    public Post(String title, String content, Board board, Category category) {
+        this.title = title;
+        this.content = content;
+        this.board = board;
+        this.category = category;
+    }
+
     // 유저 정보 생기면 사용
 //    public void checkModify(User actor) {
 //
@@ -71,10 +78,10 @@ public class Post extends BaseEntity {
         this.content = content;
     }
 
-    public Post(String title, String content, Board board, Category category) {
-        this.title = title;
-        this.content = content;
-        this.board = board;
-        this.category = category;
+    public void delete(/*User actor*/) {
+//        checkModify(actor);
+
+        this.isDeleted = true;
+
     }
 }

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -8,6 +8,8 @@ import com.team01.backend.domain.post.dto.PostDetailResponseDto;
 import com.team01.backend.domain.post.dto.PostResponseDto;
 import com.team01.backend.domain.post.entity.Post;
 import com.team01.backend.domain.post.repository.PostRepository;
+import com.team01.backend.domain.user.entity.User;
+import com.team01.backend.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +25,9 @@ import java.util.Optional;
 public class PostService {
 
     private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final BoardRepository boardRepository;
+    private final CategoryRepository categoryRepository;
 
 //    @Transactional
 //    public Post write(User author, String title, String content) {
@@ -31,8 +36,20 @@ public class PostService {
 //    }
 
     @Transactional
-    public Post write(String title, String content) {
-        Post post = new Post(title, content);
+    public Post write(String title, String content, Long boardId, Long categoryId) {
+
+        // 아직 controller에서 getActor를 사용할 수 없으므로 임시 유저 사용
+        User author = userRepository.findByEmail("user1@test.com")
+                .orElseThrow(() -> new RuntimeException("초기화 유저가 없습니다."));
+
+        // 게시판, 카테고리 조회
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 게시판입니다."));
+
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 카테고리입니다."));
+
+        Post post = new Post(author, title, content, board, category);
         return postRepository.save(post);
     }
 

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -13,7 +13,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-
 import java.util.List;
 import java.util.Optional;
 
@@ -74,6 +73,18 @@ public class PostService {
 
         return post;
 
+    }
+
+    @Transactional
+    public void delete(Long postId /*, User actor*/) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new jakarta.persistence.EntityNotFoundException("해당 게시물을 찾을 수 없습니다."));
+
+        if (post.isDeleted()) {
+            throw new IllegalArgumentException("이미 삭제된 게시물입니다.");
+        }
+
+        post.delete(/*actor*/);
     }
 
 }

--- a/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
+++ b/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
@@ -48,11 +48,23 @@ public class BaseInitData {
     @Bean
     public ApplicationRunner initData() {
         return args -> {
+            self.setMember();
             self.setBoard();
             self.setCategory();
             self.setPost();
             self.setComment();
         };
+    }
+
+    // 유저 데이터 생성
+    @Transactional
+    public void setMember() {
+
+        if (userRepository.count() > 0) return;
+
+        userRepository.save(User.builder().email("user1@test.com").nickname("유저1").password("1234").build());
+        userRepository.save(User.builder().email("user2@test.com").nickname("유저2").password("1234").build());
+
     }
 
     // 게시판 생성
@@ -71,18 +83,21 @@ public class BaseInitData {
     public void setPost(){
         if(postRepository.count() > 0) return;
 
+        User author1 = userRepository.findByEmail("user1@test.com").orElseThrow();
+        User author2 = userRepository.findByEmail("user2@test.com").orElseThrow();
+
         Board board = boardRepository.findById(1L)
                 .orElseThrow(() -> new RuntimeException("Board not found"));
         Category category = categoryRepository.findById(1L)
                 .orElseThrow(() -> new RuntimeException("Category not found"));
 
-        Post post1 = new Post("게시글 1", "내용 1", board, category);
+        Post post1 = new Post(author1, "게시글 1", "내용 1", board, category);
         postRepository.save(post1);
 
-        Post post2 = new Post("게시글 2", "내용 2", board, category);
+        Post post2 = new Post(author2, "게시글 2", "내용 2", board, category);
         postRepository.save(post2);
 
-        Post post3 = new Post("게시글 3", "내용 3", board, category);
+        Post post3 = new Post(author2, "게시글 3", "내용 3", board, category);
         postRepository.save(post3);
     }
 

--- a/backend/src/test/java/com/team01/backend/domain/comment/controller/CommentControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/comment/controller/CommentControllerTest.java
@@ -2,6 +2,10 @@ package com.team01.backend.domain.comment.controller;
 
 
 import com.jayway.jsonpath.JsonPath;
+import com.team01.backend.domain.board.entity.Board;
+import com.team01.backend.domain.board.repository.BoardRepository;
+import com.team01.backend.domain.category.entity.Category;
+import com.team01.backend.domain.category.repository.CategoryRepository;
 import com.team01.backend.domain.post.entity.Post;
 import com.team01.backend.domain.post.repository.PostRepository;
 import com.team01.backend.domain.user.entity.User;
@@ -39,6 +43,12 @@ public class CommentControllerTest {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
 
     private User testUser;
     private Post testPost;
@@ -47,11 +57,28 @@ public class CommentControllerTest {
     @BeforeEach
     void setUp() {
 
-        testUser = userRepository.findByEmail("init@init.com")
-                .orElseThrow(() -> new EntityNotFoundException("유저 없음"));
+        testUser = userRepository.save(User.builder()
+        .email("test@test.com")
+        .nickname("테스터")
+        .password("1234")
+        .build());
 
         testPost = postRepository.findAll().get(0);
         testPost2 = postRepository.findAll().get(1);
+
+        // 게시판 생성
+        Board testBoard = boardRepository.save(new Board("자유게시판", "자유롭게 글을 쓰는 곳"));
+
+        // 카테고리 생성
+        Category testCategory = categoryRepository.save(new Category(testBoard.getId(), "일반"));
+
+        String title = "테스트 게시글";
+        String content ="내용";
+
+        Post post = new Post(testUser, title, content, testBoard, testCategory);
+
+        testPost = postRepository.save(post);
+
     }
 
     @Test
@@ -79,7 +106,7 @@ public class CommentControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").exists())
                 .andExpect(jsonPath("$.data.content").value(content))
-                .andExpect(jsonPath("$.data.author").value("유저"))
+                .andExpect(jsonPath("$.data.author").value("유저1"))
                 .andExpect(jsonPath("$.data.createdAt").exists());
     }
 
@@ -234,7 +261,7 @@ public class CommentControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").exists())
                 .andExpect(jsonPath("$.data.content").value(childContent))
-                .andExpect(jsonPath("$.data.author").value("유저"))
+                .andExpect(jsonPath("$.data.author").value("유저1"))
                 .andExpect(jsonPath("$.data.createdAt").exists());
     }
 
@@ -381,7 +408,7 @@ public class CommentControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.id").value(commentId))
                 .andExpect(jsonPath("$.data.content").value(updatedContent))
-                .andExpect(jsonPath("$.data.author").value("유저"))
+                .andExpect(jsonPath("$.data.author").value("유저1"))
                 .andExpect(jsonPath("$.data.createdAt").exists());
     }
 

--- a/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
@@ -262,4 +262,27 @@ public class PostControllerTest {
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
     }
+
+
+    @Test
+    @DisplayName("글 삭제 성공")
+    void t10() throws Exception {
+//        Post post = postRepository.findById(1L).get();
+//        Long targetId = post.getId();
+
+        Post post = postService.write("테스트 제목", "테스트 내용");
+        Long targetId = post.getId();
+
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/posts/%d".formatted(targetId)))
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+
+        Post deletedPost = postRepository.findById(targetId).get();
+        assertThat(deletedPost.isDeleted()).isTrue();
+    }
 }

--- a/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
@@ -72,6 +72,8 @@ public class PostControllerTest {
     void t3() throws Exception {
         String title = "제목입니다.";
         String content = "내용입니다.";
+        Long boardId = 1L;
+        Long categoryId = 1L;
 
         ResultActions resultActions = mvc
                 .perform(
@@ -80,9 +82,11 @@ public class PostControllerTest {
                                 .content("""
                                         {
                                             "title": "%s",
-                                            "content": "%s"
+                                            "content": "%s",
+                                            "boardId" : %d,
+                                            "categoryId" : %d
                                         }
-                                        """.formatted(title, content))
+                                        """.formatted(title, content, boardId, categoryId))
                 )
                 .andDo(print());
 
@@ -104,6 +108,8 @@ public class PostControllerTest {
 
         String title = "";
         String content = "내용입니다.";
+        Long boardId = 1L;
+        Long categoryId = 1L;
 
 
         ResultActions resultActions = mvc
@@ -113,9 +119,11 @@ public class PostControllerTest {
                                 .content("""
                                     {
                                         "title": "%s",
-                                        "content": "%s"
+                                        "content": "%s",
+                                        "boardId": %d,
+                                        "categoryId": %d
                                     }
-                                    """.formatted(title, content))
+                                    """.formatted(title, content, boardId, categoryId))
                 )
                 .andDo(print());
 
@@ -133,6 +141,8 @@ public class PostControllerTest {
     void t5() throws Exception {
         String title = "제목입니다.";
         String content = "";
+        Long boardId = 1L;
+        Long categoryId = 1L;
 
         ResultActions resultActions = mvc
                 .perform(
@@ -142,9 +152,11 @@ public class PostControllerTest {
                                         """
                                         {
                                             "title": "%s",
-                                            "content": "%s"
+                                            "content": "%s",
+                                            "boardId": %d,
+                                            "categoryId": %d
                                         }
-                                        """.formatted(title, content))
+                                        """.formatted(title, content, boardId, categoryId))
                 )
                 .andDo(print());
 
@@ -258,9 +270,9 @@ public class PostControllerTest {
 
         // then
         resultActions
-                .andExpect(status().isBadRequest())
+                .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.success").value(false))
-                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
+                .andExpect(jsonPath("$.code").value("NOT_FOUND"));
     }
 
 
@@ -270,7 +282,7 @@ public class PostControllerTest {
 //        Post post = postRepository.findById(1L).get();
 //        Long targetId = post.getId();
 
-        Post post = postService.write("테스트 제목", "테스트 내용");
+        Post post = postService.write("테스트 제목", "테스트 내용", 1L, 1L);
         Long targetId = post.getId();
 
         ResultActions resultActions = mvc


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
> 관련 이슈 : #45 
> 게시글 삭제 api 구현
> 게시글 등록할 때 board, category 데이터 함께 저장

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
1. BaseInitData 
   1. 게시글 작성 매개변수 추가에 따른 유저 데이터 필요 -> setMember 추가

2. 게시글 삭제 api 구현
   1. isDeleted = true로 변경하여 soft delete
   2. 게시글이 삭제될 경우 댓글 고아 상태로 유지 (같이 삭제되지 않음)

4. 글 등록 구조 변경
   1. PostController.write() 매개변수: 기존 title, content -> title, content, boardId, categoryId로 변경
   3. PostService.write() : 임시 유저 생성, board 객체, category 객체 조회하여 Post 객체에 함께 저장

5. Test
   1. PostControllerTest : board, category 사용하도록 변경
   2. CommentControllerTest : BaseInitData 변경에 따른 유저 데이터 예상 값 변경


