### PR TITLE
fix: 카테고리 게시판 별 이름 중복 처리

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/category/entity/Category.java
+++ b/backend/src/main/java/com/team01/backend/domain/category/entity/Category.java
@@ -2,12 +2,15 @@ package com.team01.backend.domain.category.entity;
 
 import com.team01.backend.global.entity.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
 @Getter
+@Table(uniqueConstraints = { @UniqueConstraint(columnNames = { "boardId", "name" }) })
 public class Category extends BaseEntity {
     private Long boardId;
     private String name;

--- a/backend/src/main/java/com/team01/backend/domain/category/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/team01/backend/domain/category/repository/CategoryRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    boolean existsByBoardIdAndName(Long boardId, String name);
 }

--- a/backend/src/main/java/com/team01/backend/domain/category/service/CategoryService.java
+++ b/backend/src/main/java/com/team01/backend/domain/category/service/CategoryService.java
@@ -40,6 +40,11 @@ public class CategoryService {
     @Transactional
     public CategoryCreateResponseDto update(long categoryId, String name) {
         Category category = categoryRepository.findById(categoryId).orElseThrow(EntityNotFoundException::new);
+
+        if(categoryRepository.existsByBoardIdAndName(category.getBoardId(), name)){ //게시판 별 이름 중복 체크
+            throw new IllegalArgumentException("중복된 이름입니다");
+        }
+
         category.update(name);
         categoryRepository.save(category);
 

--- a/backend/src/main/java/com/team01/backend/domain/category/service/CategoryService.java
+++ b/backend/src/main/java/com/team01/backend/domain/category/service/CategoryService.java
@@ -25,7 +25,9 @@ public class CategoryService {
         if(!boardService.existsById(boardId)){ //boardId에 해당하는 게시판이 없다면 예외처리
             throw new EntityNotFoundException();
         }
-
+        if(categoryRepository.existsByBoardIdAndName(boardId, name)){
+            throw new IllegalArgumentException("중복된 이름입니다");
+        }
         Category category = new Category(boardId, name);
         categoryRepository.save(category);
         return new CategoryCreateResponseDto(category);

--- a/backend/src/test/java/com/team01/backend/domain/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/category/controller/CategoryControllerTest.java
@@ -234,6 +234,30 @@ public class CategoryControllerTest {
                 .andExpect(jsonPath("$.code").value("NOT_FOUND"))
                 .andExpect(jsonPath("$.message",startsWith("요청하신 데이터를 찾을 수 없습니다")));
     }
+
+    @Test
+    @DisplayName("카테고리 수정 테스트 - 이름 중복 체크")
+    void u4() throws Exception{
+        ResultActions resultActions = mvc
+                .perform(
+                        MockMvcRequestBuilders.put("/admin/categories/2")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "name":"카테고리 1"
+                                        }
+                                        """)
+                )
+                .andDo(print());
+        resultActions
+                .andExpect(handler().handlerType(CategoryController.class))
+                .andExpect(handler().methodName("updateCategory"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message",startsWith("중복된 이름입니다")));
+    }
+
     @Test
     @DisplayName("카테고리 조회 테스트")
     void v1() throws  Exception{

--- a/backend/src/test/java/com/team01/backend/domain/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/category/controller/CategoryControllerTest.java
@@ -118,7 +118,54 @@ public class CategoryControllerTest {
                 .andExpect(jsonPath("$.code").value("NOT_FOUND"))
                 .andExpect(jsonPath("$.message",startsWith("요청하신 데이터를 찾을 수 없습니다")));
     }
-
+    @Test
+    @DisplayName("카테고리 생성 테스트 - 게시판 별 이름 중복")
+    void c5() throws Exception{
+        ResultActions resultActions = mvc
+                .perform(
+                        MockMvcRequestBuilders.post("/admin/categories")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "boardId": 1,
+                                            "name":"카테고리 1"
+                                        }
+                                        """)
+                )
+                .andDo(print());
+        resultActions
+                .andExpect(handler().handlerType(CategoryController.class))
+                .andExpect(handler().methodName("createCategory"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message").value("중복된 이름입니다"));
+    }
+    @Test
+    @DisplayName("카테고리 생성 - 다른게시판에만 존재하는 이름 - 성공")
+    void c6() throws Exception{
+        ResultActions resultActions = mvc
+                .perform(
+                        MockMvcRequestBuilders.post("/admin/categories")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "boardId": 3,
+                                            "name":"카테고리 1"
+                                        }
+                                        """)
+                )
+                .andDo(print());
+        resultActions
+                .andExpect(handler().handlerType(CategoryController.class))
+                .andExpect(handler().methodName("createCategory"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.id").value(7))
+                .andExpect(jsonPath("$.data.boardId").value(3))
+                .andExpect(jsonPath("$.data.name").value("카테고리 1"))
+                .andExpect(jsonPath("$.data.createdAt").exists());
+    }
     @Test
     @DisplayName("카테고리 수정 테스트")
     void u1() throws Exception{


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
> 카테고리 생성, 수정시 게시판 별 중복 예외 처리
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
> CategoryService
> ㄴ 생성시 boardId, name 조합 중복 확인, 예외 처리
> ㄴ 수정시 boardId, name 조합 중복 확인,  예외 처리
> Category
> ㄴ boardId, name 복합 unique 제약 
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
