### PR TITLE
feat: 게시판별-카테고리별 글 목록 조회 api

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.team01.backend.domain.post.controller;
 import com.team01.backend.domain.post.dto.PostDetailResponseDto;
 import com.team01.backend.domain.post.dto.PostDto;
 import com.team01.backend.domain.post.dto.PostResponseDto;
+import com.team01.backend.domain.post.dto.PostSummaryDto;
 import com.team01.backend.domain.post.entity.Post;
 import com.team01.backend.domain.post.service.PostService;
 import com.team01.backend.global.response.ApiResponse;
@@ -32,11 +33,11 @@ public class PostController {
 
     // 게시판별, 카테고리별 글 목록 조회
     @GetMapping("/boards/{boardId}/categories/{categoryId}/posts")
-    public ResponseEntity<ApiResponse<List<PostResponseDto>>> getPostsByCategory(
+    public ResponseEntity<ApiResponse<List<PostSummaryDto>>> getPostsByCategory(
             @PathVariable("boardId") Long boardId,
             @PathVariable("categoryId") Long categoryId
     ) {
-        List<PostResponseDto> posts = postService.getPostsByBoardAndCategory(boardId, categoryId);
+        List<PostSummaryDto> posts = postService.getPostsByBoardAndCategory(boardId, categoryId);
         return ResponseEntity.ok(ApiResponse.ofSuccess(posts));
     }
 

--- a/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
@@ -30,6 +30,17 @@ public class PostController {
         return ResponseEntity.ok(ApiResponse.ofSuccess(posts));
     }
 
+    // 게시판별, 카테고리별 글 목록 조회
+    @GetMapping("/boards/{boardId}/categories/{categoryId}/posts")
+    public ResponseEntity<ApiResponse<List<PostResponseDto>>> getPostsByCategory(
+            @PathVariable("boardId") Long boardId,
+            @PathVariable("categoryId") Long categoryId
+    ) {
+        List<PostResponseDto> posts = postService.getPostsByBoardAndCategory(boardId, categoryId);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(posts));
+    }
+
+
     // 게시글 상세 조회
     @GetMapping("/posts/{postId}")
     public ResponseEntity<ApiResponse<PostDetailResponseDto>> getPostById(

--- a/backend/src/main/java/com/team01/backend/domain/post/dto/PostSummaryDto.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/dto/PostSummaryDto.java
@@ -1,0 +1,35 @@
+package com.team01.backend.domain.post.dto;
+
+import com.team01.backend.domain.post.entity.Post;
+
+import java.time.LocalDateTime;
+
+public record PostSummaryDto(
+        Long id,
+        String title,
+        Long boardId,
+        String boardName,
+        Long categoryId,
+        String categoryName,
+        Long authorId,
+        String authorNickname,
+        int likeCount,      // 좋아요 수 추가
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+    public PostSummaryDto(Post post) {
+        this(
+                post.getId(),
+                post.getTitle(),
+                post.getBoard().getId(),
+                post.getBoard().getName(),
+                post.getCategory().getId(),
+                post.getCategory().getName(),
+                post.getAuthor().getId(),
+                post.getAuthor().getNickname(),
+                post.getLikeCount(),
+                post.getCreatedAt(),
+                post.getModifiedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepository.java
@@ -3,6 +3,8 @@ package com.team01.backend.domain.post.repository;
 import com.team01.backend.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -10,4 +12,11 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @EntityGraph(attributePaths = {"author", "category"})
     List<Post> findByBoardIdAndIsDeletedFalse(Long boardId);
+
+    @Query("select p from Post p " +
+            "join fetch p.board " +
+            "join fetch p.category " +
+            "join fetch p.author " +
+            "where p.board.id = :boardId and p.category.id = :categoryId")
+    List<Post> findAllByBoardIdAndCategoryId(@Param("boardId") Long boardId, @Param("categoryId") Long categoryId);
 }

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -147,7 +147,7 @@ public class PostService {
             throw new IllegalArgumentException("해당 게시판에서 사용할 수 없는 카테고리입니다.");
         }
 
-        // 2. Fetch Join을 사용하여 N+1 문제를 방어하며 조회
+        // 2. Fetch Join을 사용해서 N+1 문제를 방어
         List<Post> posts = postRepository.findAllByBoardIdAndCategoryId(boardId, categoryId);
 
         return posts.stream()

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -8,6 +8,7 @@ import com.team01.backend.domain.comment.dto.CommentReadResponseDto;
 import com.team01.backend.domain.comment.service.CommentService;
 import com.team01.backend.domain.post.dto.PostDetailResponseDto;
 import com.team01.backend.domain.post.dto.PostResponseDto;
+import com.team01.backend.domain.post.dto.PostSummaryDto;
 import com.team01.backend.domain.post.entity.Post;
 import com.team01.backend.domain.post.repository.PostRepository;
 import com.team01.backend.domain.user.entity.User;
@@ -137,7 +138,7 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostResponseDto> getPostsByBoardAndCategory(Long boardId, Long categoryId) {
+    public List<PostSummaryDto> getPostsByBoardAndCategory(Long boardId, Long categoryId) {
         // 1. 카테고리가 해당 게시판 소속인지 검증 (데이터 무결성)
         Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new EntityNotFoundException("카테고리를 찾을 수 없습니다."));
@@ -150,7 +151,7 @@ public class PostService {
         List<Post> posts = postRepository.findAllByBoardIdAndCategoryId(boardId, categoryId);
 
         return posts.stream()
-                .map(PostResponseDto::new)
+                .map(PostSummaryDto::new)
                 .toList();
     }
 }

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -98,18 +98,20 @@ public class PostService {
         return PostDetailResponseDto.of(post, board, category, comments);
     }
 
-    public Optional<Post> findById(Long id) {return postRepository.findById(id);}
+    public Optional<Post> findById(Long id) {
+        return postRepository.findById(id);
+    }
 
     @Transactional
     public Post modify(Long postId, String title, String content, Long categoryId) {
 
         // 게시글 조회
         Post post = postRepository.findById(postId)
-                        .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
 
         // 변경하려고 하는 카테고리 조회
         Category category = categoryRepository.findById(categoryId)
-                        .orElseThrow(() -> new EntityNotFoundException("카테고리를 찾을 수 없습니다."));
+                .orElseThrow(() -> new EntityNotFoundException("카테고리를 찾을 수 없습니다."));
 
         // 변경하려고 하는 카테고리가 현재 게시글의 게시판에 속하는지
         if (!category.getBoardId().equals(post.getBoard().getId())) {
@@ -134,4 +136,21 @@ public class PostService {
         post.delete(/*actor*/);
     }
 
+    @Transactional(readOnly = true)
+    public List<PostResponseDto> getPostsByBoardAndCategory(Long boardId, Long categoryId) {
+        // 1. 카테고리가 해당 게시판 소속인지 검증 (데이터 무결성)
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new EntityNotFoundException("카테고리를 찾을 수 없습니다."));
+
+        if (!category.getBoardId().equals(boardId)) {
+            throw new IllegalArgumentException("해당 게시판에서 사용할 수 없는 카테고리입니다.");
+        }
+
+        // 2. Fetch Join을 사용하여 N+1 문제를 방어하며 조회
+        List<Post> posts = postRepository.findAllByBoardIdAndCategoryId(boardId, categoryId);
+
+        return posts.stream()
+                .map(PostResponseDto::new)
+                .toList();
+    }
 }

--- a/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
@@ -403,4 +403,59 @@ public class PostControllerTest {
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.code").value("NOT_FOUND"));
     }
+
+    @Test
+    @DisplayName("게시판별-카테고리별 글 목록 조회 성공")
+    void t13() throws Exception {
+
+        Long boardId = 1L;
+        Long categoryId = 1L;
+
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/boards/%d/categories/%d/posts".formatted(boardId, categoryId))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(PostController.class))
+                .andExpect(handler().methodName("getPostsByCategory"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                // PostSummaryDto 필드 검증
+                .andExpect(jsonPath("$.data[0].id").exists())
+                .andExpect(jsonPath("$.data[0].title").exists())
+                .andExpect(jsonPath("$.data[0].boardId").value(boardId))
+                .andExpect(jsonPath("$.data[0].boardName").exists())
+                .andExpect(jsonPath("$.data[0].categoryId").value(categoryId))
+                .andExpect(jsonPath("$.data[0].categoryName").exists())
+                .andExpect(jsonPath("$.data[0].authorNickname").exists())
+                .andExpect(jsonPath("$.data[0].likeCount").isNumber()) // likeCount 필드 확인
+                .andExpect(jsonPath("$.data[0].createdAt").exists())
+                .andExpect(jsonPath("$.data[0].modifiedAt").exists());
+    }
+
+    @Test
+    @DisplayName("게시판별-카테고리별 글 목록 조회 실패 - 타 게시판의 카테고리 선택")
+    void t14() throws Exception {
+
+        // 테스트 시점 기준 : 1번 게시판에는 3번 카테고리까지 존재
+        Long boardId = 1L;
+        Long invalidCategoryId = 4L;
+
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/boards/%d/categories/%d/posts".formatted(boardId, invalidCategoryId))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"))
+                .andExpect(jsonPath("$.message").value("해당 게시판에서 사용할 수 없는 카테고리입니다."));
+    }
 }

--- a/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
@@ -432,7 +432,7 @@ public class PostControllerTest {
                 .andExpect(jsonPath("$.data[0].categoryId").value(categoryId))
                 .andExpect(jsonPath("$.data[0].categoryName").exists())
                 .andExpect(jsonPath("$.data[0].authorNickname").exists())
-                .andExpect(jsonPath("$.data[0].likeCount").isNumber()) // likeCount 필드 확인
+                .andExpect(jsonPath("$.data[0].likeCount").isNumber())
                 .andExpect(jsonPath("$.data[0].createdAt").exists())
                 .andExpect(jsonPath("$.data[0].modifiedAt").exists());
     }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
- 관련 이슈 : #68 
- [POST-11]
- 게시판별-카테고리별 글 목록 조회 api를 구현했습니다.
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- PostSummaryDto
   - postId, title, board(id, name), category(id, name), author(id, name), likeCount, createdAt, modifiedAt 구성

- PostService
   - categoryId가 boardId에 속한 데이터인지 검증 로직 추가
- PostControllerTest
   - t13() : 정상적인 관계의 boardId-categoryId인 경우
   - t14() : 타 게시판의 카테고리가 선택된 경우
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 추가 구현된 기능임에 따라 WBS 문서에 아래와 같이 내용을 추가했습니다.
   - 기능 정의서 : POST-11
   - API 명세서 : /boards/{boardId}/categories/{categoryId}/posts