### PR TITLE
관리자 카테고리 기능 권한 확인 및 인증/인가 실패 응답 구조 통일

### DIFF
--- a/backend/src/main/java/com/team01/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/team01/backend/global/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.team01.backend.global.config;
 
 
+import com.team01.backend.global.security.CustomAccessDeniedHandler;
+import com.team01.backend.global.security.CustomAuthenticationEntryPoint;
 import com.team01.backend.global.security.JwtAuthenticationFilter;
 import com.team01.backend.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +29,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
-
+    private final CustomAccessDeniedHandler accessDeniedHandler; //인가 실패 응답 관리
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint; //인증 실패 응답 관리
     /**
      * [과제] 비밀번호 암호화를 위한 Encoder 빈 등록입니다.
      */
@@ -59,7 +62,12 @@ public class SecurityConfig {
                 .anyRequest().authenticated() // 그 외의 요청은 인증이 필요합니다.
             )
             // [과제] JWT 필터를 UsernamePasswordAuthenticationFilter 이전에 실행되도록 설정합니다.
-            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+            .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+            //인증 실패 및 인가 실패 응답 관리
+            .exceptionHandling(ex -> ex
+                .accessDeniedHandler(accessDeniedHandler)
+                .authenticationEntryPoint(authenticationEntryPoint)
+            );
 
         return http.build();
     }

--- a/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
+++ b/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
@@ -20,6 +20,7 @@ import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
 @Configuration

--- a/backend/src/main/java/com/team01/backend/global/security/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/team01/backend/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.team01.backend.global.security;
+
+import com.team01.backend.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler { // 인가 실패 관리
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException ex) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<Void>apiResponse = ApiResponse.ofFailure("FORBIDDEN", "권한이 없습니다.");
+
+        response.getWriter().write(
+                objectMapper.writeValueAsString(apiResponse)
+        );
+    }
+}

--- a/backend/src/main/java/com/team01/backend/global/security/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/team01/backend/global/security/CustomAccessDeniedHandler.java
@@ -3,6 +3,7 @@ package com.team01.backend.global.security;
 import com.team01.backend.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -13,7 +14,8 @@ import java.io.IOException;
 @Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler { // 인가 실패 관리
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Override
     public void handle(HttpServletRequest request,

--- a/backend/src/main/java/com/team01/backend/global/security/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/team01/backend/global/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,33 @@
+package com.team01.backend.global.security;
+
+import com.team01.backend.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import tools.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint { // 인증 실패 관리
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException ex) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ApiResponse<Void> apiResponse =
+                ApiResponse.ofFailure("UNAUTHORIZED", "인증이 필요합니다.");
+
+        response.getWriter().write(
+                objectMapper.writeValueAsString(apiResponse)
+        );
+    }
+}

--- a/backend/src/main/java/com/team01/backend/global/security/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/team01/backend/global/security/CustomAuthenticationEntryPoint.java
@@ -3,6 +3,7 @@ package com.team01.backend.global.security;
 import com.team01.backend.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -13,7 +14,8 @@ import java.io.IOException;
 @Component
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint { // 인증 실패 관리
 
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Override
     public void commence(HttpServletRequest request,

--- a/backend/src/test/java/com/team01/backend/domain/board/controller/AdminBoardControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/board/controller/AdminBoardControllerTest.java
@@ -189,7 +189,7 @@ public class AdminBoardControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized());
 //                .andExpect(jsonPath("$.success").value(false))
 //                .andExpect(jsonPath("$.message").value("Forbidden"));
     }

--- a/backend/src/test/java/com/team01/backend/domain/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/category/controller/CategoryControllerTest.java
@@ -206,7 +206,10 @@ public class CategoryControllerTest {
                 )
                 .andDo(print());
         resultActions
-                .andExpect(status().isForbidden()); //
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+                .andExpect(jsonPath("$.message",startsWith("권한이 없습니다.")));
     }
     @Test
     @DisplayName("카테고리 수정 테스트")
@@ -320,7 +323,10 @@ public class CategoryControllerTest {
                 )
                 .andDo(print());
         resultActions
-                .andExpect(status().isForbidden());
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("FORBIDDEN"))
+                .andExpect(jsonPath("$.message",startsWith("권한이 없습니다.")));
     }
 
     @Test
@@ -350,6 +356,9 @@ public class CategoryControllerTest {
                 )
                 .andDo(print());
         resultActions
-                .andExpect(status().isForbidden());
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"))
+                .andExpect(jsonPath("$.message",startsWith("인증이 필요합니다.")));
     }
 }

--- a/backend/src/test/java/com/team01/backend/domain/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/category/controller/CategoryControllerTest.java
@@ -1,12 +1,15 @@
 package com.team01.backend.domain.category.controller;
 
+import com.team01.backend.global.security.JwtTokenProvider;
 import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -16,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @SpringBootTest
+@ActiveProfiles("test")
 @Transactional
 @AutoConfigureMockMvc
 public class CategoryControllerTest {
@@ -23,12 +27,25 @@ public class CategoryControllerTest {
     @Autowired
     private MockMvc mvc;
 
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    String adminToken = "";
+    String user1Token = "";
+
+    @BeforeEach
+    void setToken(){
+        adminToken = jwtTokenProvider.createToken("admin@admin.com", "ROLE_ADMIN");
+        user1Token = jwtTokenProvider.createToken("user1@test.com", "ROLE_USER");
+    }
+
     @Test
     @DisplayName("카테고리 생성 테스트")
     void c1() throws Exception{
         ResultActions resultActions = mvc
                 .perform(
                         MockMvcRequestBuilders.post("/admin/categories")
+                                .header("Authorization", "Bearer %s".formatted(adminToken))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                         {
@@ -55,6 +72,7 @@ public class CategoryControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         MockMvcRequestBuilders.post("/admin/categories")
+                                .header("Authorization", "Bearer %s".formatted(adminToken))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                         {
@@ -77,6 +95,7 @@ public class CategoryControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         MockMvcRequestBuilders.post("/admin/categories")
+                                .header("Authorization", "Bearer %s".formatted(adminToken))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                         {
@@ -101,6 +120,7 @@ public class CategoryControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         MockMvcRequestBuilders.post("/admin/categories")
+                                .header("Authorization", "Bearer %s".formatted(adminToken))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                         {
@@ -124,6 +144,7 @@ public class CategoryControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         MockMvcRequestBuilders.post("/admin/categories")
+                                .header("Authorization", "Bearer %s".formatted(adminToken))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                         {
@@ -147,6 +168,7 @@ public class CategoryControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         MockMvcRequestBuilders.post("/admin/categories")
+                                .header("Authorization", "Bearer %s".formatted(adminToken))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                         {
@@ -166,12 +188,33 @@ public class CategoryControllerTest {
                 .andExpect(jsonPath("$.data.name").value("카테고리 1"))
                 .andExpect(jsonPath("$.data.createdAt").exists());
     }
+
+    @Test
+    @DisplayName("카테고리 생성 테스트 - 권한 없음 ")
+    void c7() throws Exception{
+        ResultActions resultActions = mvc
+                .perform(
+                        MockMvcRequestBuilders.post("/admin/categories")
+                                .header("Authorization", "Bearer %s".formatted(user1Token))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "boardId": 1,
+                                            "name":"카테고리 6"
+                                       }
+                                       """)
+                )
+                .andDo(print());
+        resultActions
+                .andExpect(status().isForbidden()); //
+    }
     @Test
     @DisplayName("카테고리 수정 테스트")
     void u1() throws Exception{
         ResultActions resultActions = mvc
                 .perform(
                         MockMvcRequestBuilders.put("/admin/categories/1")
+                                .header("Authorization", "Bearer %s".formatted(adminToken))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                         {
@@ -197,6 +240,7 @@ public class CategoryControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         MockMvcRequestBuilders.put("/admin/categories/2")
+                                .header("Authorization", "Bearer %s".formatted(adminToken))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                         {
@@ -218,6 +262,7 @@ public class CategoryControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         MockMvcRequestBuilders.put("/admin/categories/21")
+                                .header("Authorization", "Bearer %s".formatted(adminToken))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                         {
@@ -241,6 +286,7 @@ public class CategoryControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         MockMvcRequestBuilders.put("/admin/categories/2")
+                                .header("Authorization", "Bearer %s".formatted(adminToken))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                         {
@@ -259,12 +305,32 @@ public class CategoryControllerTest {
     }
 
     @Test
-    @DisplayName("카테고리 조회 테스트")
+    @DisplayName("카테고리 수정 테스트 - 권한 없음 ")
+    void u5() throws Exception{
+        ResultActions resultActions = mvc
+                .perform(
+                        MockMvcRequestBuilders.put("/admin/categories/1")
+                                .header("Authorization", "Bearer %s".formatted(user1Token))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "name":"카테고리 1 - 수정"
+                                        }
+                                        """)
+                )
+                .andDo(print());
+        resultActions
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("카테고리 관리자 조회 테스트")
     void v1() throws  Exception{
         //
         ResultActions resultActions = mvc
                 .perform(
                         MockMvcRequestBuilders.get("/admin/categories")
+                                .header("Authorization", "Bearer %s".formatted(adminToken))
                 )
                 .andDo(print());
         resultActions
@@ -273,5 +339,17 @@ public class CategoryControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data[4]").exists());
+    }
+
+    @Test
+    @DisplayName("카테고리 관리자 조회 테스트 - 권한 없음 ")
+    void v2() throws Exception{
+        ResultActions resultActions = mvc
+                .perform(
+                        MockMvcRequestBuilders.get("/admin/categories")
+                )
+                .andDo(print());
+        resultActions
+                .andExpect(status().isForbidden());
     }
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
> 카테고리 권한 확인 추가
> 인증, 인가 응답구조 통일
## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
> 인증 실패 응답 관리(CustomAuthenticationEntryPoint) -> isUnauthorized() , "UNAUTHORIZED", "인증이 필요합니다."
> 인가 실패 응답 관리 (CustomAccessDeniedHandler) -> isForbidden(), "FORBIDDEN", "권한이 없습니다."
> SecurityConfig에 2개 파일 적용
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
