### PR TITLE
refactor: 관리자 게시판 조회- isDeleted 포함

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/board/controller/AdminBoardController.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/controller/AdminBoardController.java
@@ -1,6 +1,6 @@
 package com.team01.backend.domain.board.controller;
 
-import com.team01.backend.domain.board.dto.AdminBoardResponseDto;
+import com.team01.backend.domain.board.dto.AdminBoardListResponseDto;
 import com.team01.backend.domain.board.dto.BoardCreateResponseDto;
 import com.team01.backend.domain.board.dto.BoardUpdateResponseDto;
 import com.team01.backend.domain.board.service.BoardService;
@@ -11,8 +11,6 @@ import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -75,8 +73,8 @@ public class AdminBoardController {
 
     // 게시판 다건 조회
     @GetMapping
-    public ResponseEntity<ApiResponse<List<AdminBoardResponseDto>>> getBoards() {
-        List<AdminBoardResponseDto> boards = boardService.getAllBoardsByAdmin();
+    public ResponseEntity<ApiResponse<AdminBoardListResponseDto>> getBoards() {
+        AdminBoardListResponseDto boards = boardService.getAllBoardsByAdmin();
         return ResponseEntity.ok(ApiResponse.ofSuccess(boards));
     }
 }

--- a/backend/src/main/java/com/team01/backend/domain/board/controller/AdminBoardController.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/controller/AdminBoardController.java
@@ -1,7 +1,7 @@
 package com.team01.backend.domain.board.controller;
 
+import com.team01.backend.domain.board.dto.AdminBoardResponseDto;
 import com.team01.backend.domain.board.dto.BoardCreateResponseDto;
-import com.team01.backend.domain.board.dto.BoardResponse;
 import com.team01.backend.domain.board.dto.BoardUpdateResponseDto;
 import com.team01.backend.domain.board.service.BoardService;
 import com.team01.backend.global.response.ApiResponse;
@@ -75,8 +75,8 @@ public class AdminBoardController {
 
     // 게시판 다건 조회
     @GetMapping
-    public ResponseEntity<ApiResponse<List<BoardResponse>>> getBoards() {
-        List<BoardResponse> boards = boardService.getAllBoards();
+    public ResponseEntity<ApiResponse<List<AdminBoardResponseDto>>> getBoards() {
+        List<AdminBoardResponseDto> boards = boardService.getAllBoardsByAdmin();
         return ResponseEntity.ok(ApiResponse.ofSuccess(boards));
     }
 }

--- a/backend/src/main/java/com/team01/backend/domain/board/dto/AdminBoardListResponseDto.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/dto/AdminBoardListResponseDto.java
@@ -1,0 +1,14 @@
+package com.team01.backend.domain.board.dto;
+
+import java.util.List;
+
+public record AdminBoardListResponseDto(
+        List<AdminBoardResponseDto> exist,
+        List<AdminBoardResponseDto> deleted
+) {
+   public AdminBoardListResponseDto(List<AdminBoardResponseDto> exist,List<AdminBoardResponseDto> deleted){
+      this.deleted = deleted;
+      this.exist = exist;
+
+   }
+}

--- a/backend/src/main/java/com/team01/backend/domain/board/dto/AdminBoardResponseDto.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/dto/AdminBoardResponseDto.java
@@ -1,0 +1,25 @@
+package com.team01.backend.domain.board.dto;
+
+import com.team01.backend.domain.board.entity.Board;
+
+import java.time.LocalDateTime;
+
+public record AdminBoardResponseDto(
+        Long id,
+        String boardName,
+        String description,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        boolean isDeleted
+) {
+    public AdminBoardResponseDto(Board board){
+        this(
+                board.getId(),
+                board.getName(),
+                board.getDescription(),
+                board.getCreatedAt(),
+                board.getModifiedAt(),
+                board.isDeleted()
+        );
+    }
+}

--- a/backend/src/main/java/com/team01/backend/domain/board/repository/BoardRepository.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/repository/BoardRepository.java
@@ -9,5 +9,6 @@ import java.util.Optional;
 public interface BoardRepository extends JpaRepository<Board,Long> {
     Optional<Board> findByIdAndIsDeletedFalse(Long id);
     List<Board> findAllByIsDeletedFalse();
+    List<Board> findAllByIsDeletedTrue();
     boolean existsByNameAndIsDeletedFalse(String name);
 }

--- a/backend/src/main/java/com/team01/backend/domain/board/service/BoardService.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/service/BoardService.java
@@ -1,5 +1,6 @@
 package com.team01.backend.domain.board.service;
 
+import com.team01.backend.domain.board.dto.AdminBoardResponseDto;
 import com.team01.backend.domain.board.dto.BoardCreateResponseDto;
 import com.team01.backend.domain.board.dto.BoardResponse;
 import com.team01.backend.domain.board.dto.BoardUpdateResponseDto;
@@ -34,6 +35,14 @@ public class BoardService {
         return boardRepository.findAllByIsDeletedFalse()
                 .stream()
                 .map(BoardResponse::from)
+                .toList();
+    }
+
+    // 관리자 게시판 목록 조회 (삭제된것까지 포함해서)
+    public List<AdminBoardResponseDto> getAllBoardsByAdmin() {
+        return boardRepository.findAll()
+                .stream()
+                .map(AdminBoardResponseDto::new)
                 .toList();
     }
 

--- a/backend/src/main/java/com/team01/backend/domain/board/service/BoardService.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/service/BoardService.java
@@ -1,9 +1,6 @@
 package com.team01.backend.domain.board.service;
 
-import com.team01.backend.domain.board.dto.AdminBoardResponseDto;
-import com.team01.backend.domain.board.dto.BoardCreateResponseDto;
-import com.team01.backend.domain.board.dto.BoardResponse;
-import com.team01.backend.domain.board.dto.BoardUpdateResponseDto;
+import com.team01.backend.domain.board.dto.*;
 import com.team01.backend.domain.board.entity.Board;
 import com.team01.backend.domain.board.repository.BoardRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -39,11 +36,16 @@ public class BoardService {
     }
 
     // 관리자 게시판 목록 조회 (삭제된것까지 포함해서)
-    public List<AdminBoardResponseDto> getAllBoardsByAdmin() {
-        return boardRepository.findAll()
+    public AdminBoardListResponseDto getAllBoardsByAdmin() {
+        List<AdminBoardResponseDto> exist = boardRepository.findAllByIsDeletedFalse()
                 .stream()
                 .map(AdminBoardResponseDto::new)
                 .toList();
+        List<AdminBoardResponseDto> deleted = boardRepository.findAllByIsDeletedTrue()
+                .stream()
+                .map(AdminBoardResponseDto::new)
+                .toList();
+        return new AdminBoardListResponseDto(exist, deleted);
     }
 
     // 게시판 수정, dto 형식으로 반환

--- a/backend/src/test/java/com/team01/backend/domain/board/controller/AdminBoardControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/board/controller/AdminBoardControllerTest.java
@@ -329,7 +329,7 @@ public class AdminBoardControllerTest {
                 .andExpect(handler().methodName("getBoards"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data[2]").exists());
+                .andExpect(jsonPath("$.data.[?(@.isDeleted == true)]").exists());
     }
 
 }

--- a/backend/src/test/java/com/team01/backend/domain/board/controller/AdminBoardControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/board/controller/AdminBoardControllerTest.java
@@ -329,7 +329,8 @@ public class AdminBoardControllerTest {
                 .andExpect(handler().methodName("getBoards"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data.[?(@.isDeleted == true)]").exists());
+                .andExpect(jsonPath("$.data.exist[?(@.isDeleted == true)]").doesNotExist())
+                .andExpect(jsonPath("$.data.deleted[?(@.isDeleted == true)]").exists());
     }
 
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
> 관리자 게시판 조회시 deleted 된 게시판도 가져오도록 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
> - 기존 dto에 isDeleted를 추가해 AdminBoardResponseDto를 정의
> - exist, deleted 를 프론트에서 구분하기 편하도록 dto에서 나눠서 저장하도록 구현
> - AdminBoardListResponseDto에 List<AdminBoardResponseDto> 로 exist, deleted가 들어감
## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
