### PR TITLE
feat: 댓글 좋아요 (토글) 1차 기능구현

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/comment/controller/CommentController.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/controller/CommentController.java
@@ -1,14 +1,12 @@
 package com.team01.backend.domain.comment.controller;
 
 import com.team01.backend.domain.comment.dto.CommentDeleteResponseDto;
+import com.team01.backend.domain.comment.dto.CommentLikeToggleResponseDto;
 import com.team01.backend.domain.comment.dto.CommentReadResponseDto;
 import com.team01.backend.domain.comment.dto.CommentRequestDto;
 import com.team01.backend.domain.comment.dto.CommentResponseDto;
 import com.team01.backend.domain.comment.service.CommentService;
-import com.team01.backend.domain.user.entity.User;
-import com.team01.backend.domain.user.repository.UserRepository;
 import com.team01.backend.global.response.ApiResponse;
-import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -23,7 +21,6 @@ import java.util.List;
 public class CommentController {
 
     private final CommentService commentService;
-    private final UserRepository userRepository;
 
     // COMMENT-02 댓글(답글) 조회
     @GetMapping("/posts/{postId}/comments")
@@ -56,16 +53,24 @@ public class CommentController {
         return ResponseEntity.ok(ApiResponse.ofSuccess(resDto));
     }
 
+    /** 댓글 좋아요 토글 — 한 번 호출 시 좋아요, 한 번 더 호출 시 취소 */
+    @PostMapping("/comments/{commentId}/likes")
+    public ResponseEntity<ApiResponse<CommentLikeToggleResponseDto>> toggleCommentLike(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetails userDetails) {
 
-        // COMMENT-04 댓글(답글) 삭제 — DELETE, 소프트 딜리트(서비스에서 isDeleted 처리)
+        CommentLikeToggleResponseDto dto = commentService.toggleCommentLike(commentId, userDetails.getUsername());
+        return ResponseEntity.ok(ApiResponse.ofSuccess(dto));
+    }
+
+
+    // COMMENT-04 댓글(답글) 삭제 — DELETE, 소프트 딜리트(서비스에서 isDeleted 처리)
     @DeleteMapping("/comments/{commentId}")
-    public ResponseEntity<ApiResponse<CommentDeleteResponseDto>> deleteComment(@PathVariable Long commentId) {
+    public ResponseEntity<ApiResponse<CommentDeleteResponseDto>> deleteComment(
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal UserDetails userDetails) {
 
-        // 임시 — 나중에 @AuthenticationPrincipal 로 교체
-        User user = userRepository.findById(1L)
-                .orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없어요"));
-
-        CommentDeleteResponseDto body = commentService.deleteComment(commentId, user);
+        CommentDeleteResponseDto body = commentService.deleteComment(commentId, userDetails.getUsername());
         return ResponseEntity.ok(ApiResponse.ofSuccess(body));
     }
 }

--- a/backend/src/main/java/com/team01/backend/domain/comment/dto/CommentLikeToggleResponseDto.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/dto/CommentLikeToggleResponseDto.java
@@ -1,0 +1,8 @@
+package com.team01.backend.domain.comment.dto;
+
+public record CommentLikeToggleResponseDto(
+        Long commentId,
+        int likeCount,
+        boolean liked
+) {
+}

--- a/backend/src/main/java/com/team01/backend/domain/comment/entity/Comment.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/entity/Comment.java
@@ -57,4 +57,16 @@ public class Comment extends BaseEntity {
     public void softDelete() {
         this.isDeleted = true;
     }
+
+    /** 좋아요 추가 시 {@code CommentLike} 저장과 함께 호출. */
+    public void incrementLikeCount() {
+        this.likeCount++;
+    }
+
+    /** 좋아요 취소 시 {@code CommentLike} 삭제와 함께 호출. */
+    public void decrementLikeCount() {
+        if (this.likeCount > 0) {
+            this.likeCount--;
+        }
+    }
 }

--- a/backend/src/main/java/com/team01/backend/domain/comment/entity/CommentLike.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/entity/CommentLike.java
@@ -1,0 +1,34 @@
+package com.team01.backend.domain.comment.entity;
+
+import com.team01.backend.domain.user.entity.User;
+import com.team01.backend.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+        name = "comment_likes",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_comment_likes_comment_user",
+                columnNames = {"comment_id", "user_id"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentLike extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id", nullable = false)
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    public CommentLike(Comment comment, User user) {
+        this.comment = comment;
+        this.user = user;
+    }
+}

--- a/backend/src/main/java/com/team01/backend/domain/comment/repository/CommentLikeRepository.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/repository/CommentLikeRepository.java
@@ -1,0 +1,28 @@
+package com.team01.backend.domain.comment.repository;
+
+import com.team01.backend.domain.comment.entity.Comment;
+import com.team01.backend.domain.comment.entity.CommentLike;
+import jakarta.persistence.LockModeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
+
+    /**
+     * 좋아요 토글 등 동시 요청 시 {@code likeCount}·{@code CommentLike} 정합성을 위해 댓글 행을 직렬화합니다.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Comment c JOIN FETCH c.post WHERE c.id = :id")
+    Optional<Comment> findCommentByIdAndPostForUpdate(@Param("id") Long id);
+
+    Optional<CommentLike> findByComment_IdAndUser_Id(Long commentId, Long userId);
+
+    /** 삭제된 행 수 — 0이면 멱등(이미 없음), 동시성 시 이중 감소 방지에 사용 */
+    int deleteByComment_IdAndUser_Id(Long commentId, Long userId);
+
+    long countByComment_Id(Long commentId);
+}

--- a/backend/src/main/java/com/team01/backend/domain/comment/service/CommentService.java
+++ b/backend/src/main/java/com/team01/backend/domain/comment/service/CommentService.java
@@ -1,10 +1,13 @@
 package com.team01.backend.domain.comment.service;
 
 import com.team01.backend.domain.comment.dto.CommentDeleteResponseDto;
+import com.team01.backend.domain.comment.dto.CommentLikeToggleResponseDto;
 import com.team01.backend.domain.comment.dto.CommentReadResponseDto;
 import com.team01.backend.domain.comment.dto.CommentRequestDto;
 import com.team01.backend.domain.comment.dto.CommentResponseDto;
 import com.team01.backend.domain.comment.entity.Comment;
+import com.team01.backend.domain.comment.entity.CommentLike;
+import com.team01.backend.domain.comment.repository.CommentLikeRepository;
 import com.team01.backend.domain.comment.repository.CommentRepository;
 import com.team01.backend.domain.post.entity.Post;
 import com.team01.backend.domain.post.repository.PostRepository;
@@ -26,6 +29,7 @@ import java.util.stream.Collectors;
 public class CommentService {
 
     private final CommentRepository commentRepository;
+    private final CommentLikeRepository commentLikeRepository;
     private final PostRepository postRepository;
     private final UserRepository userRepository;
 
@@ -38,16 +42,16 @@ public class CommentService {
     @Transactional
     public void writeInitComment(Long postId, User tempUser, String content,  Long parentId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없어요"));
+                .orElseThrow(() -> new EntityNotFoundException("게시글을 찾을 수 없습니다."));
         if (post.isDeleted()) {
-            throw new EntityNotFoundException("게시글을 찾을 수 없어요");
+            throw new EntityNotFoundException("게시글을 찾을 수 없습니다.");
         }
 
         // parentId 있으면 부모 댓글 찾기, 없으면 null
         Comment parent = null;
         if (parentId != null) {
             parent = commentRepository.findById(parentId)
-                    .orElseThrow(() -> new EntityNotFoundException("부모 댓글을 찾을 수 없어요"));
+                    .orElseThrow(() -> new EntityNotFoundException("부모 댓글을 찾을 수 없습니다."));
         }
 
         commentRepository.save(new Comment(post, tempUser, content,  parent));
@@ -87,7 +91,7 @@ public class CommentService {
     public CommentResponseDto writeComment(Long postId, CommentRequestDto reqDto, String email){
 
         User user = userRepository.findByEmail(email)  // ✅ DB 접근은 Service에서
-                .orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없어요"));
+                .orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다."));
 
         // 게시글 존재 확인
         Post post = postRepository.findById(postId)
@@ -115,7 +119,7 @@ public class CommentService {
 
             // 답글의 대댓글 방지
             if (parent.getParent() != null) {
-                throw new IllegalArgumentException("답글에는 답글을 달 수 없습니다");
+                throw new IllegalArgumentException("답글에는 답글을 달 수 없습니다.");
             }
         }
 
@@ -130,7 +134,7 @@ public class CommentService {
     public CommentResponseDto updateComment(Long commentId, CommentRequestDto reqDto, String email){
 
         User user = userRepository.findByEmail(email)  // ✅ DB 접근은 Service에서
-                .orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없어요"));
+                .orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다."));
 
         //댓글 존재 확인 -> code:404
         Comment comment = commentRepository.findById(commentId)
@@ -138,7 +142,7 @@ public class CommentService {
 
         //삭제된 댓글을 수정할 수 없음.
         if (comment.isDeleted()) {
-            throw new IllegalArgumentException("삭제된 댓글은 수정할 수 없어요");
+            throw new IllegalArgumentException("삭제된 댓글은 수정할 수 없습니다.");
         }
 
         if(!comment.getUser().getId().equals(user.getId())){
@@ -158,10 +162,9 @@ public class CommentService {
      * ============================================================================================================
      */
     @Transactional
-    public CommentDeleteResponseDto deleteComment(Long commentId, User loginUser) {
-        if (loginUser == null) {
-            throw new AccessDeniedException("로그인이 필요합니다.");
-        }
+    public CommentDeleteResponseDto deleteComment(Long commentId, String email) {
+        User loginUser = userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다."));
 
         Comment comment = commentRepository.findByIdWithPost(commentId)
                 .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다."));
@@ -179,6 +182,39 @@ public class CommentService {
         }
 
         comment.softDelete();
+        commentRepository.saveAndFlush(comment);
         return CommentDeleteResponseDto.of(commentId);
+    }
+
+    /*
+     * ============================================================================================================
+     * 댓글 좋아요 토글 — 미등록 시 좋아요, 이미 누른 상태면 취소 (인스타/유튜브 댓글과 동일 UX).
+     * 동시에 같은 댓글을 누를 때 {@code likeCount} 경쟁 상태를 막기 위해 댓글 행에 비관적 락을 겁니다.
+     * ============================================================================================================
+     */
+    @Transactional
+    public CommentLikeToggleResponseDto toggleCommentLike(Long commentId, String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다."));
+
+        Comment comment = commentLikeRepository.findCommentByIdAndPostForUpdate(commentId)
+                .orElseThrow(() -> new EntityNotFoundException("댓글을 찾을 수 없습니다."));
+
+        if (comment.isDeleted()) {
+            throw new IllegalArgumentException("삭제된 댓글에는 좋아요를 할 수 없습니다.");
+        }
+        if (comment.getPost().isDeleted()) {
+            throw new EntityNotFoundException("게시글을 찾을 수 없습니다.");
+        }
+
+        int removed = commentLikeRepository.deleteByComment_IdAndUser_Id(commentId, user.getId());
+        if (removed > 0) {
+            comment.decrementLikeCount();
+            return new CommentLikeToggleResponseDto(commentId, comment.getLikeCount(), false);
+        }
+
+        commentLikeRepository.save(new CommentLike(comment, user));
+        comment.incrementLikeCount();
+        return new CommentLikeToggleResponseDto(commentId, comment.getLikeCount(), true);
     }
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->

## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
## 글 좋아요 토글(좋아요 ↔ 취소)
- POST /comments/{commentId}/likes 단일 엔드포인트
- JWT(UserDetails 이메일) 기준으로 CommentLike 저장, 삭제 및 Comment.likeCount 증감
- 응답은 CommentLikeToggleResponseDto(commentId, likeCount, liked)로 반환.

## 좋아요 주체, 중복 방지
- CommentLike 엔티티 + (comment_id, user_id) 유니크 제약으로 동일 사용자 중복 좋아요 방지.

## 동시 요청 시 좋아요 수 정합성
- CommentLikeRepository.findCommentByIdAndPostForUpdate로 댓글 행 비관적 락
- deleteByComment_IdAndUser_Id 반환 건수로 취소 시에만 likeCount 감소.

## 댓글 삭제 API 인증 처리
- UserRepository.findById(1L) 임시 코드 제거 → 
- @AuthenticationPrincipal + deleteComment(commentId, userDetails.getUsername()), 서비스에서 이메일로 User 조회.

## 소프트 삭제 영속화
- deleteComment에서 softDelete 후 commentRepository.saveAndFlush(comment) 호출.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
### PR 포인트
- 동시에 같은 댓글에 요청이 몰릴 때 숫자가 어긋나지 않도록, 댓글 엔티티를 조회할 때 DB 비관적 락을 걸어 해당 댓글에 대한 토글을 순차 처리하고, CommentLike 저장, 삭제와 likeCount 변경은 모두 DB(트랜잭션) 기준으로 반영하도록 구현했습니다.
