### PR TITLE
feat : 카테고리별 게시글 목록 페이징 및 게시글 수 표시 추가(POST-08-ADD)

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/board/dto/BoardResponse.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/dto/BoardResponse.java
@@ -8,14 +8,16 @@ public record BoardResponse(
         Long id,
         String boardName,
         String description,
+        long postCount,      // 게시판별 게시글 수 (삭제된 게시글 제외)
         LocalDateTime createdAt,
         LocalDateTime modifiedAt
 ) {
-    public static BoardResponse from(Board board) {
+    public static BoardResponse from(Board board, long postCount) {
         return new BoardResponse(
                 board.getId(),
                 board.getName(),
                 board.getDescription(),
+                postCount,
                 board.getCreatedAt(),
                 board.getModifiedAt()
         );

--- a/backend/src/main/java/com/team01/backend/domain/board/service/BoardService.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/service/BoardService.java
@@ -3,6 +3,7 @@ package com.team01.backend.domain.board.service;
 import com.team01.backend.domain.board.dto.*;
 import com.team01.backend.domain.board.entity.Board;
 import com.team01.backend.domain.board.repository.BoardRepository;
+import com.team01.backend.domain.post.repository.PostRepository;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BoardService {
     private final BoardRepository boardRepository;
+    private final PostRepository postRepository;
 
     // 게시판 생성, dto 형식으로 반환
     @Transactional
@@ -31,7 +33,11 @@ public class BoardService {
     public List<BoardResponse> getAllBoards() {
         return boardRepository.findAllByIsDeletedFalse()
                 .stream()
-                .map(BoardResponse::from)
+                .map(board -> BoardResponse.from(
+                        board,
+                        // 삭제된 게시글 제외한 게시판별 게시글 수
+                        postRepository.countByBoardIdAndIsDeletedFalse(board.getId())
+                ))
                 .toList();
     }
 

--- a/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
@@ -42,11 +42,15 @@ public class PostController {
 
     // 게시판별, 카테고리별 글 목록 조회
     @GetMapping("/boards/{boardId}/categories/{categoryId}/posts")
-    public ResponseEntity<ApiResponse<List<PostSummaryDto>>> getPostsByCategory(
-            @PathVariable("boardId") Long boardId,
-            @PathVariable("categoryId") Long categoryId
+    public ResponseEntity<ApiResponse<PostPageResponseDto>> getPostsByCategory(
+            @PathVariable Long boardId,
+            @PathVariable Long categoryId,
+            @RequestParam(defaultValue = "1") int page
     ) {
-        List<PostSummaryDto> posts = postService.getPostsByBoardAndCategory(boardId, categoryId);
+        // 페이지 번호 유효성 검증 (1 이상)
+        if (page < 1) throw new IllegalArgumentException("페이지 번호는 1 이상이어야 합니다.");
+
+        PostPageResponseDto posts = postService.getPostsByBoardAndCategory(boardId, categoryId, page);
         return ResponseEntity.ok(ApiResponse.ofSuccess(posts));
     }
 

--- a/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
@@ -45,12 +45,15 @@ public class PostController {
     public ResponseEntity<ApiResponse<PostPageResponseDto>> getPostsByCategory(
             @PathVariable Long boardId,
             @PathVariable Long categoryId,
-            @RequestParam(defaultValue = "1") int page
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(required = false) String keyword
     ) {
         // 페이지 번호 유효성 검증 (1 이상)
         if (page < 1) throw new IllegalArgumentException("페이지 번호는 1 이상이어야 합니다.");
+        // 검색어 길이 검증 (50자 이하)
+        if (keyword != null && keyword.length() > 50) throw new IllegalArgumentException("검색어는 50자 이하이어야 합니다.");
 
-        PostPageResponseDto posts = postService.getPostsByBoardAndCategory(boardId, categoryId, page);
+        PostPageResponseDto posts = postService.getPostsByBoardAndCategory(boardId, categoryId, page, keyword);
         return ResponseEntity.ok(ApiResponse.ofSuccess(posts));
     }
 

--- a/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepository.java
@@ -1,6 +1,9 @@
 package com.team01.backend.domain.post.repository;
 
 import com.team01.backend.domain.post.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,10 +12,17 @@ import java.util.List;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
+    // 페이징 미적용, findAllByBoardIdAndCategoryIdAndIsDeletedFalse 로 대체
     @Query("select p from Post p " +
             "join fetch p.board " +
             "join fetch p.category " +
             "join fetch p.author " +
             "where p.board.id = :boardId and p.category.id = :categoryId")
     List<Post> findAllByBoardIdAndCategoryId(@Param("boardId") Long boardId, @Param("categoryId") Long categoryId);
+
+    // 카테고리별 게시글 목록 페이징 조회 (삭제된 게시글 제외)
+    // getPostsByBoardAndCategory (PostService) 에서 사용
+    @EntityGraph(attributePaths = {"board", "category", "author"})
+    Page<Post> findAllByBoardIdAndCategoryIdAndIsDeletedFalse(
+            Long boardId, Long categoryId, Pageable pageable);
 }

--- a/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepository.java
@@ -25,4 +25,8 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     @EntityGraph(attributePaths = {"board", "category", "author"})
     Page<Post> findAllByBoardIdAndCategoryIdAndIsDeletedFalse(
             Long boardId, Long categoryId, Pageable pageable);
+
+    // 게시판별 게시글 수 조회 (삭제된 게시글 제외)
+    // BoardService.getAllBoards에서 게시판 목록 조회 시 게시판별 게시글 수 표시에 사용
+    long countByBoardIdAndIsDeletedFalse(Long boardId);
 }

--- a/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepositoryImpl.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepositoryImpl.java
@@ -65,6 +65,9 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                 .replace("<", "")
                 .replace(">", "")
                 .replace("&", "");
+
+        // sanitized 후 빈 문자열 체크 추가
+        if (sanitized.isBlank()) return Expressions.FALSE;
         return post.title.containsIgnoreCase(sanitized);
     }
 }

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -151,7 +151,7 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostSummaryDto> getPostsByBoardAndCategory(Long boardId, Long categoryId) {
+    public PostPageResponseDto getPostsByBoardAndCategory(Long boardId, Long categoryId, int page) {
         // 1. 카테고리가 해당 게시판 소속인지 검증 (데이터 무결성)
         Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new EntityNotFoundException("카테고리를 찾을 수 없습니다."));
@@ -160,11 +160,14 @@ public class PostService {
             throw new IllegalArgumentException("해당 게시판에서 사용할 수 없는 카테고리입니다.");
         }
 
-        // 2. Fetch Join을 사용해서 N+1 문제를 방어
-        List<Post> posts = postRepository.findAllByBoardIdAndCategoryId(boardId, categoryId);
+        // 2. 페이징 조건 설정 (1-based → 0-based 변환, 최신순 정렬)
+        Pageable pageable = PageRequest.of(page - 1, PAGE_SIZE, Sort.by("createdAt").descending());
 
-        return posts.stream()
-                .map(PostSummaryDto::new)
-                .toList();
+        // 3. 삭제되지 않은 게시글만 페이징 조회 (@EntityGraph로 N+1 방지)
+        Page<PostResponseDto> postPage = postRepository
+                .findAllByBoardIdAndCategoryIdAndIsDeletedFalse(boardId, categoryId, pageable)
+                .map(PostResponseDto::new);
+
+        return PostPageResponseDto.from(postPage);
     }
 }

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -151,7 +151,7 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PostPageResponseDto getPostsByBoardAndCategory(Long boardId, Long categoryId, int page) {
+    public PostPageResponseDto getPostsByBoardAndCategory(Long boardId, Long categoryId, int page, String keyword) {
         // 1. 카테고리가 해당 게시판 소속인지 검증 (데이터 무결성)
         Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new EntityNotFoundException("카테고리를 찾을 수 없습니다."));
@@ -163,9 +163,9 @@ public class PostService {
         // 2. 페이징 조건 설정 (1-based → 0-based 변환, 최신순 정렬)
         Pageable pageable = PageRequest.of(page - 1, PAGE_SIZE, Sort.by("createdAt").descending());
 
-        // 3. 삭제되지 않은 게시글만 페이징 조회 (@EntityGraph로 N+1 방지)
+        // 3. categoryId 고정, keyword 검색 포함하여 QueryDSL로 조회
         Page<PostResponseDto> postPage = postRepository
-                .findAllByBoardIdAndCategoryIdAndIsDeletedFalse(boardId, categoryId, pageable)
+                .searchByBoardId(boardId, keyword, categoryId, pageable)
                 .map(PostResponseDto::new);
 
         return PostPageResponseDto.from(postPage);

--- a/backend/src/test/java/com/team01/backend/domain/board/controller/BoardControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/board/controller/BoardControllerTest.java
@@ -62,4 +62,20 @@ public class BoardControllerTest {
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data.length()").value(3));
     }
+
+    @Test
+    @DisplayName("게시판 목록 조회 - 게시판별 게시글 수 포함")
+    void t3() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(get("/boards"))
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(BoardController.class))
+                .andExpect(handler().methodName("getAllBoards"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data[0].postCount").exists())
+                .andExpect(jsonPath("$.data[0].postCount").isNumber());
+    }
 }

--- a/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
@@ -576,4 +576,37 @@ public class PostControllerTest {
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
     }
+
+    @Test
+    @DisplayName("게시판별-카테고리별 글 목록 조회 - 키워드 검색 성공")
+    void t23() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(get("/boards/1/categories/1/posts?page=1&keyword=첫"))
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(PostController.class))
+                .andExpect(handler().methodName("getPostsByCategory"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.posts[0].title").value("첫 번째 게시글입니다."))
+                .andExpect(jsonPath("$.data.totalElements").value(1));
+    }
+
+    @Test
+    @DisplayName("게시판별-카테고리별 글 목록 조회 - 키워드 검색 결과 없음")
+    void t24() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(get("/boards/1/categories/1/posts?page=1&keyword=존재하지않는키워드"))
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(PostController.class))
+                .andExpect(handler().methodName("getPostsByCategory"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.posts").isEmpty())
+                .andExpect(jsonPath("$.data.totalElements").value(0));
+    }
 }

--- a/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
@@ -410,7 +410,6 @@ public class PostControllerTest {
     @Test
     @DisplayName("게시판별-카테고리별 글 목록 조회 성공")
     void t13() throws Exception {
-
         Long boardId = 1L;
         Long categoryId = 1L;
 
@@ -426,18 +425,12 @@ public class PostControllerTest {
                 .andExpect(handler().methodName("getPostsByCategory"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data").isArray())
-                // PostSummaryDto 필드 검증
-                .andExpect(jsonPath("$.data[0].id").exists())
-                .andExpect(jsonPath("$.data[0].title").exists())
-                .andExpect(jsonPath("$.data[0].boardId").value(boardId))
-                .andExpect(jsonPath("$.data[0].boardName").exists())
-                .andExpect(jsonPath("$.data[0].categoryId").value(categoryId))
-                .andExpect(jsonPath("$.data[0].categoryName").exists())
-                .andExpect(jsonPath("$.data[0].authorNickname").exists())
-                .andExpect(jsonPath("$.data[0].likeCount").isNumber())
-                .andExpect(jsonPath("$.data[0].createdAt").exists())
-                .andExpect(jsonPath("$.data[0].modifiedAt").exists());
+                .andExpect(jsonPath("$.data.posts").isArray())
+                .andExpect(jsonPath("$.data.currentPage").value(1))
+                .andExpect(jsonPath("$.data.totalPages").exists())
+                .andExpect(jsonPath("$.data.totalElements").exists())
+                .andExpect(jsonPath("$.data.hasNext").exists())
+                .andExpect(jsonPath("$.data.posts[0].categoryId").value(categoryId));
     }
 
     @Test
@@ -569,5 +562,18 @@ public class PostControllerTest {
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.posts").isEmpty())
                 .andExpect(jsonPath("$.data.totalElements").value(0));
+    }
+
+    @Test
+    @DisplayName("게시판별-카테고리별 글 목록 조회 실패 - 잘못된 페이지 번호")
+    void t22() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(get("/boards/1/categories/1/posts?page=0"))
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("INVALID_INPUT"));
     }
 }


### PR DESCRIPTION
## 📌 과제 설명
1. 카테고리별 게시글 목록 조회 **페이징** 추가
2. 카테고리 별 게시글 목록 조회 시 **키워드 검색 기능** 추가
3. 게시판 목록 조회에 게시판별 **게시글 수** 표시
- close #78 

## 👩‍💻 요구 사항과 구현 내용

**카테고리별 게시글 목록 조회 페이징 추가**
- `PostRepository`, `PostService`, `PostController` 수정
- 기존 게시판별 조회 페이징과 동일한 구조 적용

**카테고리별 게시글 목록 조회에 키워드 검색 추가**
- `keyword` 파라미터 추가 및 길이 검증 (50자 이하)
- 기존 `searchByBoardId` QueryDSL 구현체 재사용

**게시판 목록 조회에 게시판별 게시글 수 추가**
- `BoardResponse`에 `postCount` 필드 추가
- `PostRepository` COUNT 쿼리로 게시판별 게시글 수 조회

## ✅ PR 포인트 & 궁금한 점

**COUNT 쿼리 방식 선택 이유**
게시판 목록 페이지에서는 게시글 데이터 없이 숫자만 필요하기 때문에 `Pageable` 방식 대신 별도 COUNT 쿼리를 선택했습니다. `Pageable`은 내부적으로 데이터 조회 쿼리와 COUNT 쿼리 두 개를 날리는데, 숫자만 필요한 상황에서 불필요한 데이터 조회 쿼리가 추가로 나가는 것은 낭비라고 판단했습니다.

**검색 기능 구체화**
- `GET /boards/{boardId}/posts` (게시판 전체 목록)
  - 키워드(제목) 검색 가능 → `?page=1&keyword=검색어`
  - 카테고리 필터링 가능 → `?page=1&categoryId=1`
  - 키워드 + 카테고리 동시 검색 가능 → `?page=1&keyword=검색어&categoryId=1`

- `GET /boards/{boardId}/categories/{categoryId}/posts` (카테고리별 목록)
  - 카테고리는 URL에 이미 고정되어 있으므로 카테고리 필터링 불필요
  - 키워드(제목) 검색만 가능 → `?page=1&keyword=검색어`