### PR TITLE
refactor : 리팩토링(refactor/POST-08) + merge 한 후에 gradle sync 부탁드립니다.

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("io.jsonwebtoken:jjwt-api:0.11.5")
     implementation("com.querydsl:querydsl-jpa:5.1.0:jakarta")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2")
     annotationProcessor("com.querydsl:querydsl-apt:5.1.0:jakarta")
     annotationProcessor("jakarta.annotation:jakarta.annotation-api")
     annotationProcessor("jakarta.persistence:jakarta.persistence-api")

--- a/backend/src/main/java/com/team01/backend/domain/board/controller/BoardController.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/controller/BoardController.java
@@ -3,6 +3,8 @@ package com.team01.backend.domain.board.controller;
 import com.team01.backend.domain.board.dto.BoardResponse;
 import com.team01.backend.domain.board.service.BoardService;
 import com.team01.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -11,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "게시판", description = "게시판 관련 API")
 @RestController
 @RequestMapping("/boards")
 @RequiredArgsConstructor
@@ -18,6 +21,7 @@ public class BoardController {
     private final BoardService boardService;
 
     // 게시판 목록 조회
+    @Operation(summary = "게시판 목록 조회", description = "게시판별 게시글 수 포함")
     @GetMapping
     public ResponseEntity<ApiResponse<List<BoardResponse>>> getAllBoards() {
         List<BoardResponse> boards = boardService.getAllBoards();

--- a/backend/src/main/java/com/team01/backend/domain/board/service/BoardService.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/service/BoardService.java
@@ -10,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -31,12 +33,20 @@ public class BoardService {
 
     // 게시판 목록 조회
     public List<BoardResponse> getAllBoards() {
-        return boardRepository.findAllByIsDeletedFalse()
+        List<Board> boards = boardRepository.findAllByIsDeletedFalse();
+
+        // 게시판별 게시글 수 한 번에 조회 (N+1 방지)
+        Map<Long, Long> postCountMap = postRepository.countByBoardGrouped()
                 .stream()
+                .collect(Collectors.toMap(
+                        row -> (Long) row[0],
+                        row -> (Long) row[1]
+                ));
+
+        return boards.stream()
                 .map(board -> BoardResponse.from(
                         board,
-                        // 삭제된 게시글 제외한 게시판별 게시글 수
-                        postRepository.countByBoardIdAndIsDeletedFalse(board.getId())
+                        postCountMap.getOrDefault(board.getId(), 0L)
                 ))
                 .toList();
     }

--- a/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
@@ -61,7 +61,12 @@ public class PostController {
             @PathVariable Long postId,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        String email = userDetails != null ? userDetails.getUsername() : null;
+        // 비로그인 사용자에 대한 예외 처리
+        if (userDetails == null) {
+            throw new IllegalArgumentException("로그인이 필요한 서비스입니다.");
+        }
+
+        String email = userDetails.getUsername();
         PostDetailResponseDto post = postService.getPostById(postId, email);
         return ResponseEntity.ok(ApiResponse.ofSuccess(post));
     }

--- a/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
@@ -4,6 +4,8 @@ import com.team01.backend.domain.post.dto.*;
 import com.team01.backend.domain.post.entity.Post;
 import com.team01.backend.domain.post.service.PostService;
 import com.team01.backend.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -16,6 +18,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "게시글", description = "게시글 관련 API")
 @Validated
 @RestController
 @RequiredArgsConstructor
@@ -30,6 +33,7 @@ public class PostController {
     }
 
     // 게시판별 글 목록 조회
+    @Operation(summary = "게시판별 글 목록 조회", description = "키워드 검색, 카테고리 필터, 페이징 지원")
     @GetMapping("/boards/{boardId}/posts")
     public ResponseEntity<ApiResponse<PostPageResponseDto>> getPostsByBoardId(
             @PathVariable Long boardId,
@@ -42,6 +46,7 @@ public class PostController {
     }
 
     // 게시판별, 카테고리별 글 목록 조회
+    @Operation(summary = "게시판별-카테고리별 글 목록 조회", description = "키워드 검색, 페이징 지원")
     @GetMapping("/boards/{boardId}/categories/{categoryId}/posts")
     public ResponseEntity<ApiResponse<PostPageResponseDto>> getPostsByCategory(
             @PathVariable Long boardId,
@@ -55,6 +60,7 @@ public class PostController {
 
 
     // 게시글 상세 조회
+    @Operation(summary = "게시글 상세 조회", description = "비로그인 사용자 접근 불가, 작성자 여부 포함")
     @GetMapping("/posts/{postId}")
     public ResponseEntity<ApiResponse<PostDetailResponseDto>> getPostById(
             @PathVariable Long postId,

--- a/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
@@ -5,6 +5,7 @@ import com.team01.backend.domain.post.entity.Post;
 import com.team01.backend.domain.post.service.PostService;
 import com.team01.backend.global.response.ApiResponse;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
@@ -12,27 +13,30 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
-
+@Validated
 @RestController
 @RequiredArgsConstructor
 public class PostController {
     private final PostService postService;
 
+    // 검증 로직 분리
+    private void validateLogin(UserDetails userDetails) {
+        if (userDetails == null) {
+            throw new IllegalArgumentException("로그인이 필요한 서비스입니다.");
+        }
+    }
+
     // 게시판별 글 목록 조회
     @GetMapping("/boards/{boardId}/posts")
     public ResponseEntity<ApiResponse<PostPageResponseDto>> getPostsByBoardId(
             @PathVariable Long boardId,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(required = false) String keyword,
+            @RequestParam(defaultValue = "1") @Min(1) int page,
+            @RequestParam(required = false) @Size(max = 50) String keyword,
             @RequestParam(required = false) Long categoryId
     ) {
-        if (page < 1) throw new IllegalArgumentException("페이지 번호는 1 이상이어야 합니다.");
-        if (keyword != null && keyword.length() > 50) throw new IllegalArgumentException("검색어는 50자 이하이어야 합니다.");
-
         PostPageResponseDto posts = postService.getPostsByBoardId(boardId, page, keyword, categoryId);
         return ResponseEntity.ok(ApiResponse.ofSuccess(posts));
     }
@@ -42,14 +46,9 @@ public class PostController {
     public ResponseEntity<ApiResponse<PostPageResponseDto>> getPostsByCategory(
             @PathVariable Long boardId,
             @PathVariable Long categoryId,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(required = false) String keyword
+            @RequestParam(defaultValue = "1") @Min(1) int page,
+            @RequestParam(required = false) @Size(max = 50) String keyword
     ) {
-        // 페이지 번호 유효성 검증 (1 이상)
-        if (page < 1) throw new IllegalArgumentException("페이지 번호는 1 이상이어야 합니다.");
-        // 검색어 길이 검증 (50자 이하)
-        if (keyword != null && keyword.length() > 50) throw new IllegalArgumentException("검색어는 50자 이하이어야 합니다.");
-
         PostPageResponseDto posts = postService.getPostsByBoardAndCategory(boardId, categoryId, page, keyword);
         return ResponseEntity.ok(ApiResponse.ofSuccess(posts));
     }
@@ -61,10 +60,7 @@ public class PostController {
             @PathVariable Long postId,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        // 비로그인 사용자에 대한 예외 처리
-        if (userDetails == null) {
-            throw new IllegalArgumentException("로그인이 필요한 서비스입니다.");
-        }
+        validateLogin(userDetails);
 
         String email = userDetails.getUsername();
         PostDetailResponseDto post = postService.getPostById(postId, email);

--- a/backend/src/main/java/com/team01/backend/domain/post/dto/PostDetailResponseDto.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/dto/PostDetailResponseDto.java
@@ -1,5 +1,6 @@
 package com.team01.backend.domain.post.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.team01.backend.domain.board.entity.Board;
 import com.team01.backend.domain.category.entity.Category;
 import com.team01.backend.domain.comment.dto.CommentReadResponseDto;
@@ -18,7 +19,9 @@ public record PostDetailResponseDto(
         String content,
         String author,
         int likeCount,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime modifiedAt,
         List<CommentReadResponseDto> comments,
         boolean isOwner

--- a/backend/src/main/java/com/team01/backend/domain/post/dto/PostResponseDto.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/dto/PostResponseDto.java
@@ -1,5 +1,6 @@
 package com.team01.backend.domain.post.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.team01.backend.domain.post.entity.Post;
 
 import java.time.LocalDateTime;
@@ -11,7 +12,9 @@ public record PostResponseDto(
         Long categoryId,
         String categoryName,
         int likeCount,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdAt,
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime modifiedAt
 ) {
     public PostResponseDto(Post post) {

--- a/backend/src/main/java/com/team01/backend/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/entity/Post.java
@@ -17,6 +17,10 @@ import java.util.List;
 @Getter
 @AllArgsConstructor
 @NoArgsConstructor
+@Table(indexes = {
+        // 게시판별 게시글 목록 조회 최적화 (board_id + isDeleted 필터링, createdAt 정렬)
+        @Index(name = "idx_post_board_deleted_created", columnList = "board_id, isDeleted, createdAt")
+})
 public class Post extends BaseEntity {
 
     private String title;

--- a/backend/src/main/java/com/team01/backend/domain/post/entity/Post.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/entity/Post.java
@@ -15,7 +15,6 @@ import java.util.List;
 
 @Entity
 @Getter
-@AllArgsConstructor
 @NoArgsConstructor
 @Table(indexes = {
         // 게시판별 게시글 목록 조회 최적화 (board_id + isDeleted 필터링, createdAt 정렬)

--- a/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepository.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepository.java
@@ -1,14 +1,13 @@
 package com.team01.backend.domain.post.repository;
 
 import com.team01.backend.domain.post.entity.Post;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
@@ -20,13 +19,11 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
             "where p.board.id = :boardId and p.category.id = :categoryId")
     List<Post> findAllByBoardIdAndCategoryId(@Param("boardId") Long boardId, @Param("categoryId") Long categoryId);
 
-    // 카테고리별 게시글 목록 페이징 조회 (삭제된 게시글 제외)
-    // getPostsByBoardAndCategory (PostService) 에서 사용
-    @EntityGraph(attributePaths = {"board", "category", "author"})
-    Page<Post> findAllByBoardIdAndCategoryIdAndIsDeletedFalse(
-            Long boardId, Long categoryId, Pageable pageable);
+    // 전체 게시판별 게시글 수 한 번에 조회 - getAllBoards N+1 해결
+    @Query("SELECT p.board.id, COUNT(p) FROM Post p WHERE p.isDeleted = false GROUP BY p.board.id")
+    List<Object[]> countByBoardGrouped();
 
-    // 게시판별 게시글 수 조회 (삭제된 게시글 제외)
-    // BoardService.getAllBoards에서 게시판 목록 조회 시 게시판별 게시글 수 표시에 사용
-    long countByBoardIdAndIsDeletedFalse(Long boardId);
+    // 게시글 상세 조회 - board, category, author 한 번에 조회 (N+1 방지)
+    @EntityGraph(attributePaths = {"board", "category", "author"})
+    Optional<Post> findWithDetailsById(Long id);
 }

--- a/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepositoryImpl.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/repository/PostRepositoryImpl.java
@@ -57,17 +57,10 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         return post.category.id.eq(categoryId);
     }
 
-    // 검색어 유효성 검사 및 XSS 방지 처리 후 제목 검색 조건 반환 (null이면 전체 조회, 공백이면 빈 리스트 반환)
+    // sanitize 로직 제거, Filter에서 이미 처리됨
     private BooleanExpression containsKeyword(String keyword) {
         if (keyword == null) return null;
         if (keyword.isBlank()) return Expressions.FALSE;
-        String sanitized = keyword.trim()
-                .replace("<", "")
-                .replace(">", "")
-                .replace("&", "");
-
-        // sanitized 후 빈 문자열 체크 추가
-        if (sanitized.isBlank()) return Expressions.FALSE;
-        return post.title.containsIgnoreCase(sanitized);
+        return post.title.containsIgnoreCase(keyword.trim());
     }
 }

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -83,7 +83,7 @@ public class PostService {
     }
 
     public PostDetailResponseDto getPostById(Long postId, String email) {
-        Post post = postRepository.findById(postId)
+        Post post = postRepository.findWithDetailsById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 게시글입니다."));
 
         if (post.isDeleted()) {
@@ -107,8 +107,7 @@ public class PostService {
             currentUser = userRepository.findByEmail(email).orElse(null);
         }
 
-        boolean isOwner = currentUser != null &&
-                post.getAuthor().getId().equals(currentUser.getId());
+        boolean isOwner = currentUser != null && post.getAuthor().getId().equals(currentUser.getId());
 
         return PostDetailResponseDto.of(post, board, category, comments, isOwner);
     }

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -42,6 +42,39 @@ public class PostService {
 
     private static final int PAGE_SIZE = 20;
 
+    // 페이징 공통 메서드(헬퍼 메서드)
+    private Pageable toPageable(int page) {
+        return PageRequest.of(page - 1, PAGE_SIZE, Sort.by("createdAt").descending());
+    }
+
+    // 조회 시 검증 로직 따로 분리
+    private void validatePost(Post post) {
+        if (post.isDeleted()) {
+            throw new EntityNotFoundException("존재하지 않는 게시글입니다.");
+        }
+
+        Board board = post.getBoard();
+        if (board == null || board.isDeleted()) {
+            throw new EntityNotFoundException("존재하지 않는 게시판입니다.");
+        }
+
+        Category category = post.getCategory();
+        if (category == null) {
+            throw new EntityNotFoundException("존재하지 않는 카테고리입니다.");
+        }
+    }
+
+    // 카테고리가 해당 게시판 소속인지 검증
+    private void validateCategoryInBoard(Long categoryId, Long boardId) {
+        Category category = categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new EntityNotFoundException("카테고리를 찾을 수 없습니다."));
+
+        // 카테고리가 요청한 게시판 소속이 아니면 예외
+        if (!category.getBoardId().equals(boardId)) {
+            throw new IllegalArgumentException("해당 게시판에서 사용할 수 없는 카테고리입니다.");
+        }
+    }
+
 //    @Transactional
 //    public Post write(User author, String title, String content) {
 //        Post post = new Post(author, title, content);
@@ -69,11 +102,12 @@ public class PostService {
         return postRepository.count();
     }
 
+    // 게시판별 게시글 목록 페이징 조회 (키워드 검색, 카테고리 필터 포함)
     public PostPageResponseDto getPostsByBoardId(Long boardId, int page, String keyword, Long categoryId) {
         boardRepository.findByIdAndIsDeletedFalse(boardId)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 게시판입니다."));
 
-        Pageable pageable = PageRequest.of(page - 1, PAGE_SIZE, Sort.by("createdAt").descending());
+        Pageable pageable = toPageable(page);  // 교체
 
         Page<PostResponseDto> postPage = postRepository
                 .searchByBoardId(boardId, keyword, categoryId, pageable)
@@ -82,34 +116,24 @@ public class PostService {
         return PostPageResponseDto.from(postPage);
     }
 
+    // 게시글 상세 조회 (비로그인 사용자는 Controller에서 차단, 작성자 여부 포함)
     public PostDetailResponseDto getPostById(Long postId, String email) {
         Post post = postRepository.findWithDetailsById(postId)
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 게시글입니다."));
 
-        if (post.isDeleted()) {
-            throw new EntityNotFoundException("존재하지 않는 게시글입니다.");
-        }
-
-        Board board = post.getBoard();
-        if (board == null || board.isDeleted()) {
-            throw new EntityNotFoundException("존재하지 않는 게시판입니다.");
-        }
-
-        Category category = post.getCategory();
-        if (category == null) {
-            throw new EntityNotFoundException("존재하지 않는 카테고리입니다.");
-        }
+        validatePost(post);
 
         List<CommentReadResponseDto> comments = commentService.getCommentsByPostId(postId);
 
-        User currentUser = null;
-        if (email != null) {
-            currentUser = userRepository.findByEmail(email).orElse(null);
-        }
+        // JWT 인증된 사용자면 조회, 비로그인(토큰 없음)이면 null
+        User currentUser = (email != null)
+                ? userRepository.findByEmail(email).orElse(null)
+                : null;
 
+        // 작성자 본인 여부 확인 (비로그인이거나 작성자가 아니면 false)
         boolean isOwner = currentUser != null && post.getAuthor().getId().equals(currentUser.getId());
 
-        return PostDetailResponseDto.of(post, board, category, comments, isOwner);
+        return PostDetailResponseDto.of(post, post.getBoard(), post.getCategory(), comments, isOwner);
     }
 
     public Optional<Post> findById(Long id) {
@@ -168,18 +192,10 @@ public class PostService {
 
     @Transactional(readOnly = true)
     public PostPageResponseDto getPostsByBoardAndCategory(Long boardId, Long categoryId, int page, String keyword) {
-        // 1. 카테고리가 해당 게시판 소속인지 검증 (데이터 무결성)
-        Category category = categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new EntityNotFoundException("카테고리를 찾을 수 없습니다."));
+        validateCategoryInBoard(categoryId, boardId);
+        Pageable pageable = toPageable(page);
 
-        if (!category.getBoardId().equals(boardId)) {
-            throw new IllegalArgumentException("해당 게시판에서 사용할 수 없는 카테고리입니다.");
-        }
-
-        // 2. 페이징 조건 설정 (1-based → 0-based 변환, 최신순 정렬)
-        Pageable pageable = PageRequest.of(page - 1, PAGE_SIZE, Sort.by("createdAt").descending());
-
-        // 3. categoryId 고정, keyword 검색 포함하여 QueryDSL로 조회
+        // categoryId 고정, keyword 검색 포함하여 QueryDSL로 조회
         Page<PostResponseDto> postPage = postRepository
                 .searchByBoardId(boardId, keyword, categoryId, pageable)
                 .map(PostResponseDto::new);

--- a/backend/src/main/java/com/team01/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/team01/backend/global/config/SecurityConfig.java
@@ -58,7 +58,6 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**").permitAll() // 로그인, 회원가입은 모두 허용합니다.
                 .requestMatchers(HttpMethod.GET, "/boards/**").permitAll()  // board는 로그인 없이 가능하므로 허용하기
-                .requestMatchers(HttpMethod.GET, "/posts/**").permitAll() // 임시 허용
                 .requestMatchers("/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated() // 그 외의 요청은 인증이 필요합니다.
             )

--- a/backend/src/main/java/com/team01/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/team01/backend/global/config/SecurityConfig.java
@@ -64,6 +64,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/**").permitAll() // 로그인, 회원가입은 모두 허용합니다.
                 .requestMatchers(HttpMethod.GET, "/boards/**").permitAll()  // board는 로그인 없이 가능하므로 허용하기
                 .requestMatchers("/h2-console/**").permitAll()
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll() // Swagger 허용
                 .requestMatchers("/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated() // 그 외의 요청은 인증이 필요합니다.
             )

--- a/backend/src/main/java/com/team01/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/team01/backend/global/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/auth/**").permitAll() // 로그인, 회원가입은 모두 허용합니다.
                 .requestMatchers(HttpMethod.GET, "/boards/**").permitAll()  // board는 로그인 없이 가능하므로 허용하기
+                .requestMatchers(HttpMethod.GET, "/posts/**").permitAll() // 임시 허용
                 .requestMatchers("/admin/**").hasRole("ADMIN")
                 .anyRequest().authenticated() // 그 외의 요청은 인증이 필요합니다.
             )

--- a/backend/src/main/java/com/team01/backend/global/filter/XssFilter.java
+++ b/backend/src/main/java/com/team01/backend/global/filter/XssFilter.java
@@ -1,0 +1,18 @@
+package com.team01.backend.global.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+// 모든 요청에 XssRequestWrapper 적용
+@Component
+public class XssFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+        chain.doFilter(new XssRequestWrapper((HttpServletRequest) request), response);
+    }
+}

--- a/backend/src/main/java/com/team01/backend/global/filter/XssRequestWrapper.java
+++ b/backend/src/main/java/com/team01/backend/global/filter/XssRequestWrapper.java
@@ -1,0 +1,34 @@
+package com.team01.backend.global.filter;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
+// 요청 파라미터의 XSS 방지 처리를 위한 래퍼 클래스
+public class XssRequestWrapper extends HttpServletRequestWrapper {
+
+    public XssRequestWrapper(HttpServletRequest request) {
+        super(request);
+    }
+
+    @Override
+    public String getParameter(String name) {
+        String value = super.getParameter(name);
+        return sanitize(value);
+    }
+
+    @Override
+    public String[] getParameterValues(String name) {
+        String[] values = super.getParameterValues(name);
+        if (values == null) return null;
+        for (int i = 0; i < values.length; i++) {
+            values[i] = sanitize(values[i]);
+        }
+        return values;
+    }
+
+    // 특수문자 제거로 XSS 방지
+    private String sanitize(String value) {
+        if (value == null) return null;
+        return value.replace("<", "").replace(">", "").replace("&", "");
+    }
+}

--- a/backend/src/main/java/com/team01/backend/global/security/CustomAccessDeniedHandler.java
+++ b/backend/src/main/java/com/team01/backend/global/security/CustomAccessDeniedHandler.java
@@ -3,7 +3,7 @@ package com.team01.backend.global.security;
 import com.team01.backend.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
@@ -12,10 +12,11 @@ import tools.jackson.databind.ObjectMapper;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler { // 인가 실패 관리
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    // 필드 주입 -> 생성자 주입으로 수정
+    private final ObjectMapper objectMapper;
 
     @Override
     public void handle(HttpServletRequest request,

--- a/backend/src/main/java/com/team01/backend/global/security/CustomAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/team01/backend/global/security/CustomAuthenticationEntryPoint.java
@@ -3,6 +3,7 @@ package com.team01.backend.global.security;
 import com.team01.backend.global.response.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -12,10 +13,11 @@ import tools.jackson.databind.ObjectMapper;
 import java.io.IOException;
 
 @Component
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint { // 인증 실패 관리
 
-    @Autowired
-    private ObjectMapper objectMapper;
+    // 필드 주입 -> 생성자 주입으로 수정
+    private final ObjectMapper objectMapper;
 
     @Override
     public void commence(HttpServletRequest request,

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -6,3 +6,7 @@ spring:
       naming:
         # 엔티티 필드명 그대로 DB 컬럼명(카멜케이스, 언더스코어 변환 없음)
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -6,7 +6,3 @@ spring:
       naming:
         # 엔티티 필드명 그대로 DB 컬럼명(카멜케이스, 언더스코어 변환 없음)
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -7,6 +7,12 @@ spring:
         # 엔티티 필드명 그대로 DB 컬럼명(카멜케이스, 언더스코어 변환 없음)
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 
+# Swagger UI 활성화
+springdoc:
+  swagger-ui:
+    enabled: true
+  api-docs:
+    enabled: true
 
 # [신규 추가] JWT 보안 설정을 위한 비밀키
 jwt:

--- a/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
@@ -716,4 +716,17 @@ public class PostControllerTest {
                 .andExpect(jsonPath("$.data.posts").isEmpty())
                 .andExpect(jsonPath("$.data.totalElements").value(0));
     }
+
+    @Test
+    @DisplayName("게시글 상세 조회 실패 - 비로그인 사용자")
+    void t25() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(get("/posts/1"))
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("UNAUTHORIZED"));
+    }
 }

--- a/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
+++ b/backend/src/test/java/com/team01/backend/domain/post/controller/PostControllerTest.java
@@ -10,6 +10,7 @@ import com.team01.backend.domain.post.repository.PostRepository;
 import com.team01.backend.domain.post.service.PostService;
 import com.team01.backend.global.security.JwtTokenProvider;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,14 +56,13 @@ public class PostControllerTest {
                         post("/api/auth/login")
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
-                                        {
-                                            "email": "%s",
-                                            "password": "%s"
-                                        }
-                                        """.formatted(email, password)))
+                                    {
+                                        "email": "%s",
+                                        "password": "%s"
+                                    }
+                                    """.formatted(email, password)))
                 .andReturn().getResponse().getContentAsString();
 
-        // JsonPath를 사용하여 토큰 추출
         return JsonPath.read(loginResponse, "$.data");
     }
 
@@ -73,8 +73,7 @@ public class PostControllerTest {
 
     @BeforeEach
     void setToken() {
-        user1Token = jwtTokenProvider.createToken("user1@test.com", "ROLE_USER");
-
+        user1Token = jwtTokenProvider.createAccessToken("user1@test.com", "ROLE_USER");
     }
 
     @Test
@@ -393,7 +392,7 @@ public class PostControllerTest {
     void t8() throws Exception {
         ResultActions resultActions = mvc
                 .perform(get("/posts/1")
-                        .header("Authorization", "Bearer " + user1Token))
+                        .cookie(new Cookie("accessToken", user1Token)))
                 .andDo(print());
 
         resultActions
@@ -416,7 +415,7 @@ public class PostControllerTest {
     void t9() throws Exception {
         ResultActions resultActions = mvc
                 .perform(get("/posts/999")
-                        .header("Authorization", "Bearer " + user1Token))
+                        .cookie(new Cookie("accessToken", user1Token)))
                 .andDo(print());
 
         resultActions
@@ -488,7 +487,7 @@ public class PostControllerTest {
 
         ResultActions resultActions = mvc
                 .perform(get("/posts/%d".formatted(post.getId()))
-                        .header("Authorization", "Bearer " + user1Token))
+                        .cookie(new Cookie("accessToken", user1Token)))
                 .andDo(print());
 
         resultActions


### PR DESCRIPTION
## 📌 과제 설명
응답 DTO 날짜 형식 통일, 게시글 조회 N+1 문제 해결, 비로그인 접근 제한, 서비스/컨트롤러 리팩토링, XSS 방지 Filter 이동, Swagger 문서화를 진행했습니다.
- close #82 

## 👩‍💻 요구 사항과 구현 내용

- **응답 DTO 날짜 형식 통일**
- **N+1 문제 해결**
- **비로그인 사용자 예외 처리(게시글 상세 조회 시)**
- **PostService 및 PostController 리팩토링**
  - Pageable 생성 헬퍼 메서드 추출로 중복 제거
  - 게시글 검증 로직 `validatePost()`로 분리
  - 카테고리 소속 검증 로직 `validateCategoryInBoard()`로 분리
  - 비로그인 사용자 조회 코드 삼항 연산자로 간결화
  - `userDetails` null 체크 `validateLogin()`으로 분리
  - `@Validated` + `@Min`, `@Size`로 파라미터 검증 개선
  - 미사용 `@AllArgsConstructor` 제거
- **XSS 방지 처리를 Filter 레이어로 이동**
- **테스트 코드 쿠키 방식으로 교체**
- **ObjectMapper 생성자 주입으로 수정**
- **Swagger 문서화**
  - springdoc-openapi 3.0.2 추가 (Spring Boot 4.x 호환 버전)
  - `SecurityConfig` Swagger 경로 허용 추가
  - 게시판, 게시글 API `@Operation`, `@Tag` 추가

## ✅ PR 포인트 & 궁금한 점
Swagger 문서화를 진행했는데, 현재 게시판/게시글 관련 API에만 `@Operation`, `@Tag`가 적용된 상태입니다.
- Swagger UI : `http://localhost:8080/swagger-ui/index.html`
<img width="920" height="619" alt="image" src="https://github.com/user-attachments/assets/de897e6f-7e71-4830-ba13-7ef0d8294856" />
<br>

- springdoc-openapi 3.0.2 의존성을 추가했으니 **Gradle Sync** 한 번씩 부탁드립니다.
- `application.yml`에 아래 설정이 추가되어 있습니다.
```yaml
    springdoc:
      swagger-ui:
        enabled: true
      api-docs:
        enabled: true
```