### PR TITLE
feat : 게시글 페이지 프론트 초기 구현(frontend-post)

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/board/controller/BoardController.java
+++ b/backend/src/main/java/com/team01/backend/domain/board/controller/BoardController.java
@@ -2,12 +2,15 @@ package com.team01.backend.domain.board.controller;
 
 import com.team01.backend.domain.board.dto.BoardResponse;
 import com.team01.backend.domain.board.service.BoardService;
+import com.team01.backend.domain.category.dto.CategoryResponseDto;
+import com.team01.backend.domain.category.service.CategoryService;
 import com.team01.backend.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,6 +22,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BoardController {
     private final BoardService boardService;
+    private final CategoryService categoryService;
 
     // 게시판 목록 조회
     @Operation(summary = "게시판 목록 조회", description = "게시판별 게시글 수 포함")
@@ -26,5 +30,14 @@ public class BoardController {
     public ResponseEntity<ApiResponse<List<BoardResponse>>> getAllBoards() {
         List<BoardResponse> boards = boardService.getAllBoards();
         return ResponseEntity.ok(ApiResponse.ofSuccess(boards));
+    }
+
+    // 게시판별 카테고리 목록 조회 (비로그인 허용, 글쓰기 페이지 카테고리 선택용)
+    @GetMapping("/{boardId}/categories")
+    public ResponseEntity<ApiResponse<List<CategoryResponseDto>>> getCategoriesByBoard(
+            @PathVariable Long boardId
+    ) {
+        List<CategoryResponseDto> categories = categoryService.listByBoardId(boardId);
+        return ResponseEntity.ok(ApiResponse.ofSuccess(categories));
     }
 }

--- a/backend/src/main/java/com/team01/backend/domain/category/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/team01/backend/domain/category/repository/CategoryRepository.java
@@ -4,7 +4,10 @@ import com.team01.backend.domain.category.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
     boolean existsByBoardIdAndName(Long boardId, String name);
+    List<Category> findByBoardId(Long boardId);
 }

--- a/backend/src/main/java/com/team01/backend/domain/category/service/CategoryService.java
+++ b/backend/src/main/java/com/team01/backend/domain/category/service/CategoryService.java
@@ -57,4 +57,11 @@ public class CategoryService {
                                 .toList();
 
     }
+
+    // 게시판별 카테고리 목록 조회 (글쓰기 페이지 카테고리 드롭다운용)
+    public List<CategoryResponseDto> listByBoardId(Long boardId) {
+        return categoryRepository.findByBoardId(boardId).stream()
+                .map(CategoryResponseDto::new)
+                .toList();
+    }
 }

--- a/frontend/src/app/boards/[boardId]/posts/page.tsx
+++ b/frontend/src/app/boards/[boardId]/posts/page.tsx
@@ -1,0 +1,343 @@
+/**
+ * 게시글 목록 페이지
+ */
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { KeyboardEvent, useCallback, useEffect, useMemo, useState } from "react";
+
+type Post = {
+  id: number;
+  title: string;
+  author: string;
+  categoryId: number;
+  categoryName: string;
+  likeCount: number;
+  createdAt: string;
+  modifiedAt: string;
+};
+
+type PostPage = {
+  posts: Post[];
+  currentPage: number;
+  totalPages: number;
+  totalElements: number;
+  hasNext: boolean;
+};
+
+type ApiResponse<T> = {
+  success: boolean;
+  code: string | null;
+  message: string | null;
+  data: T;
+};
+
+const PAGE_GROUP_SIZE = 5;
+
+function getApiBaseUrl() {
+  return process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+export default function PostListPage() {
+  const params = useParams<{ boardId: string }>();
+  const boardId = params.boardId;
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const page = Math.max(1, Number(searchParams.get("page") ?? "1") || 1);
+  const keyword = searchParams.get("keyword")?.trim() ?? "";
+  const categoryId = searchParams.get("categoryId")?.trim() ?? "";
+
+  const [searchInput, setSearchInput] = useState(keyword);
+  const [postPage, setPostPage] = useState<PostPage | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const updateQuery = useCallback(
+    (next: { page?: number; keyword?: string; categoryId?: string }) => {
+      const nextPage = next.page ?? page;
+      const nextKeyword = next.keyword ?? keyword;
+      const nextCategoryId = next.categoryId ?? categoryId;
+
+      const query = new URLSearchParams();
+      query.set("page", String(Math.max(1, nextPage)));
+
+      if (nextKeyword) {
+        query.set("keyword", nextKeyword);
+      }
+
+      if (nextCategoryId) {
+        query.set("categoryId", nextCategoryId);
+      }
+
+      router.push(`/boards/${boardId}/posts?${query.toString()}`);
+    },
+    [boardId, categoryId, keyword, page, router],
+  );
+
+  const fetchPosts = useCallback(async () => {
+    setIsLoading(true);
+    setErrorMessage("");
+
+    try {
+      const query = new URLSearchParams();
+      query.set("page", String(page));
+      if (keyword) {
+        query.set("keyword", keyword);
+      }
+      if (categoryId) {
+        query.set("categoryId", categoryId);
+      }
+
+      const res = await fetch(`${getApiBaseUrl()}/boards/${boardId}/posts?${query.toString()}`, {
+        method: "GET",
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        if (res.status === 401) {
+          throw new Error("로그인이 필요합니다. 로그인 후 다시 시도해 주세요.");
+        }
+        throw new Error(`게시글을 불러오지 못했습니다. (${res.status})`);
+      }
+
+      const json = (await res.json()) as ApiResponse<PostPage>;
+
+      if (!json.success) {
+        throw new Error(json.message ?? "게시글 조회에 실패했습니다.");
+      }
+
+      setPostPage(json.data);
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage("알 수 없는 오류가 발생했습니다.");
+      }
+      setPostPage(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [boardId, categoryId, keyword, page]);
+
+  useEffect(() => {
+    setSearchInput(keyword);
+  }, [keyword]);
+
+  useEffect(() => {
+    fetchPosts();
+  }, [fetchPosts]);
+
+  const pageNumbers = useMemo(() => {
+    if (!postPage || postPage.totalPages <= 0) {
+      return [] as number[];
+    }
+
+    const groupIndex = Math.floor((postPage.currentPage - 1) / PAGE_GROUP_SIZE);
+    const start = groupIndex * PAGE_GROUP_SIZE + 1;
+    const end = Math.min(postPage.totalPages, start + PAGE_GROUP_SIZE - 1);
+
+    return Array.from({ length: end - start + 1 }, (_, idx) => start + idx);
+  }, [postPage]);
+
+  const categories = useMemo(() => {
+    const source = postPage?.posts ?? [];
+    const dedup = new Map<number, string>();
+
+    source.forEach((post) => {
+      if (!dedup.has(post.categoryId)) {
+        dedup.set(post.categoryId, post.categoryName);
+      }
+    });
+
+    return Array.from(dedup.entries()).map(([id, name]) => ({ id, name }));
+  }, [postPage]);
+
+  const hasPosts = !!postPage && postPage.posts.length > 0;
+
+  const onSearchEnter = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === "Enter") {
+      updateQuery({ page: 1, keyword: searchInput.trim() });
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-zinc-50 px-6 py-8">
+      <main className="mx-auto flex w-full max-w-6xl flex-col gap-6">
+        <header className="flex flex-col gap-3 rounded-xl border border-zinc-200 bg-white p-5">
+          <p className="text-sm text-zinc-500">게시글 목록</p>
+          <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div className="flex items-center gap-2">
+              <input
+                type="text"
+                value={searchInput}
+                onChange={(event) => setSearchInput(event.target.value)}
+                onKeyDown={onSearchEnter}
+                placeholder="제목 검색 (Enter)"
+                className="h-10 w-72 rounded-full border border-zinc-300 px-4 text-sm outline-none transition focus:border-zinc-500"
+              />
+              <button
+                type="button"
+                onClick={() => updateQuery({ page: 1, keyword: searchInput.trim() })}
+                className="h-10 rounded-full border border-zinc-300 px-4 text-sm font-medium hover:bg-zinc-100"
+              >
+                검색
+              </button>
+              {keyword && (
+                <button
+                  type="button"
+                  onClick={() => updateQuery({ page: 1, keyword: "" })}
+                  className="h-10 rounded-full border border-zinc-200 px-4 text-sm text-zinc-500 hover:bg-zinc-100"
+                >
+                  검색 초기화
+                </button>
+              )}
+            </div>
+
+            <div className="flex items-center gap-2 text-sm">
+              <button className="rounded-md bg-zinc-900 px-3 py-1.5 font-semibold text-white">
+                최신순
+              </button>
+              <button className="cursor-not-allowed rounded-md bg-zinc-100 px-3 py-1.5 text-zinc-400">
+                인기순(준비중)
+              </button>
+            </div>
+          </div>
+        </header>
+
+        <section className="grid gap-6 md:grid-cols-[220px_1fr]">
+          <aside className="rounded-xl border border-zinc-200 bg-white p-4">
+            <p className="mb-3 text-sm font-semibold text-zinc-700">카테고리</p>
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => updateQuery({ page: 1, categoryId: "" })}
+                className={`rounded-full border px-3 py-1 text-xs ${
+                  !categoryId
+                    ? "border-zinc-900 bg-zinc-900 text-white"
+                    : "border-zinc-300 text-zinc-600 hover:bg-zinc-100"
+                }`}
+              >
+                전체
+              </button>
+              {categories.map((category) => {
+                const active = categoryId === String(category.id);
+                return (
+                  <button
+                    key={category.id}
+                    type="button"
+                    onClick={() => updateQuery({ page: 1, categoryId: String(category.id) })}
+                    className={`rounded-full border px-3 py-1 text-xs ${
+                      active
+                        ? "border-zinc-900 bg-zinc-900 text-white"
+                        : "border-zinc-300 text-zinc-600 hover:bg-zinc-100"
+                    }`}
+                  >
+                    {category.name}
+                  </button>
+                );
+              })}
+            </div>
+            <p className="mt-3 text-xs text-zinc-400">* 현재 페이지 데이터 기준 카테고리 노출</p>
+          </aside>
+
+          <div className="rounded-xl border border-zinc-200 bg-white p-4">
+            <div className="mb-4 flex items-center justify-between text-sm text-zinc-500">
+              <span>총 {postPage?.totalElements ?? 0}개</span>
+              <span>페이지 {postPage?.currentPage ?? page}</span>
+            </div>
+
+            {errorMessage && (
+              <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+                {errorMessage}
+              </div>
+            )}
+
+            {isLoading ? (
+              <div className="py-12 text-center text-sm text-zinc-400">로딩 중...</div>
+            ) : !hasPosts ? (
+              <div className="py-12 text-center text-sm text-zinc-400">게시글이 없습니다.</div>
+            ) : (
+              <ul className="divide-y divide-zinc-200 border-y border-zinc-200">
+                {postPage.posts.map((post) => (
+                  <li key={post.id} className="transition hover:bg-zinc-50">
+                    <Link
+                      href={`/posts/${post.id}`}
+                      className="flex items-center justify-between gap-4 px-3 py-4"
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate font-medium text-zinc-900">{post.title}</p>
+                        <p className="mt-1 text-xs text-zinc-500">{post.categoryName}</p>
+                      </div>
+                      <div className="shrink-0 text-right text-xs text-zinc-500">
+                        <p>{post.author}</p>
+                        <p>좋아요 {post.likeCount}</p>
+                        <p>{formatDate(post.createdAt)}</p>
+                      </div>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            <div className="mt-6 flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  disabled={!postPage || postPage.currentPage <= 1}
+                  onClick={() => updateQuery({ page: Math.max(1, page - 1) })}
+                  className="rounded border border-zinc-300 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  이전
+                </button>
+                {pageNumbers.map((number) => {
+                  const active = number === postPage?.currentPage;
+                  return (
+                    <button
+                      key={number}
+                      type="button"
+                      onClick={() => updateQuery({ page: number })}
+                      className={`rounded px-3 py-1 text-sm ${
+                        active ? "bg-zinc-900 text-white" : "border border-zinc-300 text-zinc-700"
+                      }`}
+                    >
+                      {number}
+                    </button>
+                  );
+                })}
+                <button
+                  type="button"
+                  disabled={!postPage || !postPage.hasNext}
+                  onClick={() => updateQuery({ page: page + 1 })}
+                  className="rounded border border-zinc-300 px-3 py-1 text-sm disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  다음
+                </button>
+              </div>
+
+              <Link href="/posts/write" className="rounded-md bg-zinc-900 px-5 py-2 text-sm font-semibold text-white hover:bg-zinc-700">
+                글쓰기
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/posts/[postId]/page.tsx
+++ b/frontend/src/app/posts/[postId]/page.tsx
@@ -1,0 +1,805 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, usePathname, useRouter } from "next/navigation";
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+
+type Comment = {
+  id: number;
+  content: string;
+  author: string;
+  likeCount: number;
+  createdAt: string;
+  modifiedAt: string;
+  replies?: Comment[];
+};
+
+type PostDetail = {
+  id: number;
+  boardId: number;
+  boardName: string;
+  categoryId: number;
+  categoryName: string;
+  title: string;
+  content: string;
+  author: string;
+  likeCount: number;
+  createdAt: string;
+  modifiedAt: string;
+  comments: Comment[];
+  isOwner: boolean;
+};
+
+type MyPageResponse = {
+  email: string;
+  nickname: string;
+  profileImage: string;
+  role: string;
+};
+
+type ApiResponse<T> = {
+  success: boolean;
+  code: string | null;
+  message: string | null;
+  data: T;
+};
+
+type PostLikeResponse = {
+  liked: boolean;
+  likeCount: number;
+};
+
+type CommentLikeResponse = {
+  commentId: number;
+  likeCount: number;
+  liked: boolean;
+};
+
+function getApiBaseUrl() {
+  return process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
+}
+
+function formatDate(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat("ko-KR", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+}
+
+type CommentItemProps = {
+  comment: Comment;
+  depth?: number;
+  canManage: (author: string) => boolean;
+  getCommentLikeUi: (comment: Comment) => { liked: boolean; likeCount: number };
+  onToggleCommentLike: (commentId: number) => void;
+  editingCommentId: number | null;
+  editingCommentContent: string;
+  setEditingCommentContent: (value: string) => void;
+  onStartCommentEdit: (comment: Comment) => void;
+  onCancelCommentEdit: () => void;
+  onSubmitCommentEdit: (commentId: number) => void;
+  onDeleteComment: (commentId: number) => void;
+};
+
+function CommentItem({
+  comment,
+  depth = 0,
+  canManage,
+  getCommentLikeUi,
+  onToggleCommentLike,
+  editingCommentId,
+  editingCommentContent,
+  setEditingCommentContent,
+  onStartCommentEdit,
+  onCancelCommentEdit,
+  onSubmitCommentEdit,
+  onDeleteComment,
+}: CommentItemProps) {
+  const replies = comment.replies ?? [];
+  const [isRepliesOpen, setIsRepliesOpen] = useState(false);
+  const isEditing = editingCommentId === comment.id;
+  const isOwner = canManage(comment.author);
+  const likeUi = getCommentLikeUi(comment);
+
+  // 하위 CommentItem에 전달할 공통 props
+  const commentItemProps = {
+    canManage,
+    getCommentLikeUi,
+    onToggleCommentLike,
+    editingCommentId,
+    editingCommentContent,
+    setEditingCommentContent,
+    onStartCommentEdit,
+    onCancelCommentEdit,
+    onSubmitCommentEdit,
+    onDeleteComment,
+  };
+
+  return (
+    <li className={`rounded-md border border-zinc-200 bg-white p-3 ${depth > 0 ? "ml-5" : ""}`}>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-zinc-900">{comment.author}</p>
+
+          {isEditing ? (
+            <div className="mt-2 flex gap-2">
+              <input
+                type="text"
+                value={editingCommentContent}
+                onChange={(event) => setEditingCommentContent(event.target.value)}
+                className="h-9 flex-1 rounded-md border border-zinc-300 px-3 text-sm outline-none focus:border-zinc-500"
+              />
+              <button
+                type="button"
+                onClick={() => onSubmitCommentEdit(comment.id)}
+                className="rounded-md bg-zinc-900 px-3 text-xs text-white hover:bg-zinc-700"
+              >
+                저장
+              </button>
+              <button
+                type="button"
+                onClick={onCancelCommentEdit}
+                className="rounded-md border border-zinc-300 px-3 text-xs text-zinc-700 hover:bg-zinc-100"
+              >
+                취소
+              </button>
+            </div>
+          ) : (
+            <p className="mt-1 whitespace-pre-wrap text-sm text-zinc-700">{comment.content}</p>
+          )}
+
+          <div className="mt-2 flex items-center gap-3 text-xs text-zinc-500">
+            <span>{formatDate(comment.createdAt)}</span>
+            <button
+              type="button"
+              onClick={() => onToggleCommentLike(comment.id)}
+              className="hover:text-zinc-700"
+            >
+              {likeUi.liked ? "♥" : "♡"} {likeUi.likeCount}
+            </button>
+          </div>
+        </div>
+
+        {isOwner && !isEditing && (
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => onStartCommentEdit(comment)}
+              className="rounded-md border border-zinc-300 px-2 py-1 text-xs text-zinc-700 hover:bg-zinc-100"
+            >
+              수정
+            </button>
+            <button
+              type="button"
+              onClick={() => onDeleteComment(comment.id)}
+              className="rounded-md border border-red-300 px-2 py-1 text-xs text-red-600 hover:bg-red-50"
+            >
+              삭제
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* 답글 토글 버튼 - 답글 있을 때만 표시 */}
+      {replies.length > 0 && (
+        <button
+          type="button"
+          onClick={() => setIsRepliesOpen((prev) => !prev)}
+          className="mt-2 text-xs text-zinc-500 hover:text-zinc-700"
+        >
+          {isRepliesOpen ? "▲ 답글 접기" : `▼ 답글 ${replies.length}개 보기`}
+        </button>
+      )}
+
+      {/* 답글 목록 - 토글 상태에 따라 표시 */}
+      {isRepliesOpen && replies.length > 0 && (
+        <ul className="mt-3 space-y-2">
+          {replies.map((reply) => (
+            <CommentItem
+              key={reply.id}
+              comment={reply}
+              depth={depth + 1}
+              {...commentItemProps}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+export default function PostDetailPage() {
+  const params = useParams<{ postId: string }>();
+  const pathname = usePathname();
+  const router = useRouter();
+  const postId = params.postId;
+
+  const [post, setPost] = useState<PostDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isAuthRequired, setIsAuthRequired] = useState(false);
+
+  const [myNickname, setMyNickname] = useState<string | null>(null);
+
+  const [commentContent, setCommentContent] = useState("");
+  const [isCommentSubmitting, setIsCommentSubmitting] = useState(false);
+
+  const [isDeletingPost, setIsDeletingPost] = useState(false);
+  const [isPostLikeLoading, setIsPostLikeLoading] = useState(false);
+  const [postLiked, setPostLiked] = useState(false);
+
+  const [isEditingPost, setIsEditingPost] = useState(false);
+  const [editingTitle, setEditingTitle] = useState("");
+  const [editingContent, setEditingContent] = useState("");
+  const [isSavingPostEdit, setIsSavingPostEdit] = useState(false);
+
+  const [editingCommentId, setEditingCommentId] = useState<number | null>(null);
+  const [editingCommentContent, setEditingCommentContent] = useState("");
+  const [commentLikeUi, setCommentLikeUi] = useState
+    <Record<number, { liked: boolean; likeCount: number }>
+  >({});
+
+  const loginHref = useMemo(() => {
+    const query = new URLSearchParams();
+    query.set("next", pathname ?? `/posts/${postId}`);
+    return `/login?${query.toString()}`;
+  }, [pathname, postId]);
+
+  const canManageComment = useCallback(
+    (author: string) => {
+      if (!myNickname) return false;
+      return author === myNickname;
+    },
+    [myNickname],
+  );
+
+  const fetchMe = useCallback(async () => {
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/api/users/me`, {
+        method: "GET",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        setMyNickname(null);
+        return;
+      }
+      const json = (await res.json()) as ApiResponse<MyPageResponse>;
+      if (json.success) {
+        setMyNickname(json.data.nickname);
+      }
+    } catch {
+      setMyNickname(null);
+    }
+  }, []);
+
+  const fetchPost = useCallback(async () => {
+    setIsLoading(true);
+    setErrorMessage("");
+    setIsAuthRequired(false);
+
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/posts/${postId}`, {
+        method: "GET",
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        if (res.status === 401) {
+          setIsAuthRequired(true);
+          throw new Error("게시글 상세는 로그인이 필요합니다. 로그인 후 다시 시도해 주세요.");
+        }
+        if (res.status === 403) throw new Error("이 게시글에 접근할 권한이 없습니다.");
+        if (res.status === 404) throw new Error("게시글을 찾을 수 없습니다.");
+        throw new Error(`게시글을 불러오지 못했습니다. (${res.status})`);
+      }
+
+      const json = (await res.json()) as ApiResponse<PostDetail>;
+      if (!json.success) {
+        throw new Error(json.message ?? "게시글 상세 조회에 실패했습니다.");
+      }
+
+      setPost(json.data);
+      setEditingTitle(json.data.title);
+      setEditingContent(json.data.content);
+      setPostLiked(false);
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage("알 수 없는 오류가 발생했습니다.");
+      }
+      setPost(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [postId]);
+
+  useEffect(() => {
+    fetchPost();
+    fetchMe();
+  }, [fetchMe, fetchPost]);
+
+  async function handleTogglePostLike() {
+    if (!post || isPostLikeLoading) return;
+    setIsPostLikeLoading(true);
+    setErrorMessage("");
+
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/posts/${post.id}/likes`, {
+        method: "POST",
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        if (res.status === 401) {
+          setIsAuthRequired(true);
+          throw new Error("로그인 후 좋아요를 누를 수 있습니다.");
+        }
+        throw new Error(`좋아요 처리에 실패했습니다. (${res.status})`);
+      }
+
+      const json = (await res.json()) as ApiResponse<PostLikeResponse>;
+      if (!json.success) throw new Error(json.message ?? "좋아요 처리에 실패했습니다.");
+
+      setPostLiked(json.data.liked);
+      setPost((prev) => (prev ? { ...prev, likeCount: json.data.likeCount } : prev));
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage("알 수 없는 오류가 발생했습니다.");
+      }
+    } finally {
+      setIsPostLikeLoading(false);
+    }
+  }
+
+  async function handleCreateComment(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const content = commentContent.trim();
+    if (!content) {
+      setErrorMessage("댓글 내용을 입력해 주세요.");
+      return;
+    }
+
+    setIsCommentSubmitting(true);
+    setErrorMessage("");
+
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/posts/${postId}/comments`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ content, parentId: null }),
+      });
+
+      if (!res.ok) {
+        if (res.status === 401) {
+          setIsAuthRequired(true);
+          throw new Error("로그인 후 댓글을 작성할 수 있습니다.");
+        }
+        throw new Error(`댓글 작성에 실패했습니다. (${res.status})`);
+      }
+
+      const json = (await res.json()) as ApiResponse<unknown>;
+      if (!json.success) throw new Error(json.message ?? "댓글 작성에 실패했습니다.");
+
+      setCommentContent("");
+      await fetchPost();
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage("알 수 없는 오류가 발생했습니다.");
+      }
+    } finally {
+      setIsCommentSubmitting(false);
+    }
+  }
+
+  async function handleToggleCommentLike(commentId: number) {
+    setErrorMessage("");
+
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/comments/${commentId}/likes`, {
+        method: "POST",
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        if (res.status === 401) {
+          setIsAuthRequired(true);
+          throw new Error("로그인 후 댓글 좋아요를 누를 수 있습니다.");
+        }
+        throw new Error(`댓글 좋아요 처리에 실패했습니다. (${res.status})`);
+      }
+
+      const json = (await res.json()) as ApiResponse<CommentLikeResponse>;
+      if (!json.success) throw new Error(json.message ?? "댓글 좋아요 처리에 실패했습니다.");
+
+      setCommentLikeUi((prev) => ({
+        ...prev,
+        [commentId]: { liked: json.data.liked, likeCount: json.data.likeCount },
+      }));
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage("알 수 없는 오류가 발생했습니다.");
+      }
+    }
+  }
+
+  function getCommentLikeUi(comment: Comment) {
+    return commentLikeUi[comment.id] ?? { liked: false, likeCount: comment.likeCount };
+  }
+
+  function startEditComment(comment: Comment) {
+    setEditingCommentId(comment.id);
+    setEditingCommentContent(comment.content);
+  }
+
+  function cancelEditComment() {
+    setEditingCommentId(null);
+    setEditingCommentContent("");
+  }
+
+  async function submitEditComment(commentId: number) {
+    const content = editingCommentContent.trim();
+    if (!content) {
+      setErrorMessage("댓글 내용을 입력해 주세요.");
+      return;
+    }
+
+    setErrorMessage("");
+
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/comments/${commentId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ content, parentId: null }),
+      });
+
+      if (!res.ok) {
+        if (res.status === 401) {
+          setIsAuthRequired(true);
+          throw new Error("로그인 후 댓글을 수정할 수 있습니다.");
+        }
+        if (res.status === 403) throw new Error("본인 댓글만 수정할 수 있습니다.");
+        throw new Error(`댓글 수정에 실패했습니다. (${res.status})`);
+      }
+
+      const json = (await res.json()) as ApiResponse<unknown>;
+      if (!json.success) throw new Error(json.message ?? "댓글 수정에 실패했습니다.");
+
+      cancelEditComment();
+      await fetchPost();
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage("알 수 없는 오류가 발생했습니다.");
+      }
+    }
+  }
+
+  async function handleDeleteComment(commentId: number) {
+    const confirmed = window.confirm("댓글을 삭제하시겠습니까?");
+    if (!confirmed) return;
+
+    setErrorMessage("");
+
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/comments/${commentId}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        if (res.status === 401) {
+          setIsAuthRequired(true);
+          throw new Error("로그인 후 댓글을 삭제할 수 있습니다.");
+        }
+        if (res.status === 403) throw new Error("본인 댓글만 삭제할 수 있습니다.");
+        throw new Error(`댓글 삭제에 실패했습니다. (${res.status})`);
+      }
+
+      await fetchPost();
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage("알 수 없는 오류가 발생했습니다.");
+      }
+    }
+  }
+
+  async function handleSavePostEdit() {
+    if (!post) return;
+
+    const title = editingTitle.trim();
+    const content = editingContent.trim();
+    if (title.length < 2 || content.length < 2) {
+      setErrorMessage("제목/내용은 최소 2자 이상이어야 합니다.");
+      return;
+    }
+
+    setIsSavingPostEdit(true);
+    setErrorMessage("");
+
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/posts/${post.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ title, content, categoryId: post.categoryId }),
+      });
+
+      if (!res.ok) {
+        if (res.status === 401) {
+          setIsAuthRequired(true);
+          throw new Error("로그인 후 게시글을 수정할 수 있습니다.");
+        }
+        if (res.status === 403) throw new Error("작성자만 게시글을 수정할 수 있습니다.");
+        throw new Error(`게시글 수정에 실패했습니다. (${res.status})`);
+      }
+
+      const json = (await res.json()) as ApiResponse<unknown>;
+      if (!json.success) throw new Error(json.message ?? "게시글 수정에 실패했습니다.");
+
+      setIsEditingPost(false);
+      await fetchPost();
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage("알 수 없는 오류가 발생했습니다.");
+      }
+    } finally {
+      setIsSavingPostEdit(false);
+    }
+  }
+
+  async function handleDeletePost() {
+    if (!post) return;
+
+    const confirmed = window.confirm("정말 삭제하시겠습니까?");
+    if (!confirmed) return;
+
+    setIsDeletingPost(true);
+    setErrorMessage("");
+
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/posts/${post.id}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+
+      if (!res.ok) {
+        if (res.status === 401) {
+          setIsAuthRequired(true);
+          throw new Error("로그인 후 삭제할 수 있습니다.");
+        }
+        if (res.status === 403) throw new Error("작성자만 삭제할 수 있습니다.");
+        throw new Error(`게시글 삭제에 실패했습니다. (${res.status})`);
+      }
+
+      router.push(`/boards/${post.boardId}/posts`);
+    } catch (error) {
+      if (error instanceof Error) {
+        setErrorMessage(error.message);
+      } else {
+        setErrorMessage("알 수 없는 오류가 발생했습니다.");
+      }
+    } finally {
+      setIsDeletingPost(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-zinc-50 px-6 py-8">
+      <main className="mx-auto flex w-full max-w-4xl flex-col gap-4">
+        <header className="rounded-xl border border-zinc-200 bg-white px-5 py-4">
+          <p className="text-xs text-zinc-500">{post?.boardName ?? "게시판"}</p>
+          <h1 className="mt-1 text-2xl font-semibold text-zinc-900">게시글 상세</h1>
+        </header>
+
+        {errorMessage && (
+          <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+            {errorMessage}
+          </div>
+        )}
+
+        {isAuthRequired && (
+          <section className="rounded-xl border border-zinc-200 bg-white p-5">
+            <p className="text-sm text-zinc-700">로그인이 필요한 페이지입니다.</p>
+            <div className="mt-3 flex gap-2">
+              <Link
+                href={loginHref}
+                className="inline-flex rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-700"
+              >
+                로그인 하러 가기
+              </Link>
+              <button
+                type="button"
+                onClick={fetchPost}
+                className="inline-flex rounded-md border border-zinc-300 px-4 py-2 text-sm text-zinc-700 hover:bg-zinc-100"
+              >
+                다시 시도
+              </button>
+            </div>
+          </section>
+        )}
+
+        {isLoading ? (
+          <section className="rounded-xl border border-zinc-200 bg-white p-8 text-center text-sm text-zinc-400">
+            로딩 중...
+          </section>
+        ) : !post ? (
+          !isAuthRequired && (
+            <section className="rounded-xl border border-zinc-200 bg-white p-8 text-center text-sm text-zinc-400">
+              게시글을 찾을 수 없습니다.
+            </section>
+          )
+        ) : (
+          <>
+            <section className="rounded-xl border border-zinc-200 bg-white p-5">
+              <div className="mb-4 flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <p className="inline-flex rounded-full bg-zinc-100 px-3 py-1 text-xs text-zinc-600">
+                    {post.categoryName}
+                  </p>
+
+                  {isEditingPost ? (
+                    <div className="mt-2 space-y-2">
+                      <input
+                        type="text"
+                        value={editingTitle}
+                        onChange={(event) => setEditingTitle(event.target.value)}
+                        className="h-10 w-full rounded-md border border-zinc-300 px-3 text-sm outline-none focus:border-zinc-500"
+                      />
+                      <textarea
+                        value={editingContent}
+                        onChange={(event) => setEditingContent(event.target.value)}
+                        rows={6}
+                        className="w-full rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500"
+                      />
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          onClick={handleSavePostEdit}
+                          disabled={isSavingPostEdit}
+                          className="rounded-md bg-zinc-900 px-3 py-1.5 text-xs text-white hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {isSavingPostEdit ? "저장 중..." : "저장"}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setIsEditingPost(false);
+                            setEditingTitle(post.title);
+                            setEditingContent(post.content);
+                          }}
+                          className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs text-zinc-700 hover:bg-zinc-100"
+                        >
+                          취소
+                        </button>
+                      </div>
+                    </div>
+                  ) : (
+                    <>
+                      <h2 className="mt-2 text-xl font-semibold text-zinc-900">{post.title}</h2>
+                      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-zinc-500">
+                        <span>작성자 {post.author}</span>
+                        <span>작성일 {formatDate(post.createdAt)}</span>
+                        <span>수정일 {formatDate(post.modifiedAt)}</span>
+                      </div>
+                    </>
+                  )}
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={handleTogglePostLike}
+                    disabled={isPostLikeLoading}
+                    className="rounded-md border border-zinc-300 px-3 py-1.5 text-sm text-zinc-700 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {postLiked ? "♥" : "♡"} {post.likeCount}
+                  </button>
+
+                  {post.isOwner && !isEditingPost && (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => setIsEditingPost(true)}
+                        className="rounded-md border border-zinc-300 px-3 py-1.5 text-xs text-zinc-700 hover:bg-zinc-100"
+                      >
+                        수정
+                      </button>
+                      <button
+                        type="button"
+                        onClick={handleDeletePost}
+                        disabled={isDeletingPost}
+                        className="rounded-md border border-red-300 px-3 py-1.5 text-xs text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+                      >
+                        {isDeletingPost ? "삭제 중..." : "삭제"}
+                      </button>
+                    </>
+                  )}
+                </div>
+              </div>
+
+              {!isEditingPost && (
+                <div className="whitespace-pre-wrap border-t border-zinc-200 pt-4 text-sm leading-6 text-zinc-800">
+                  {post.content}
+                </div>
+              )}
+            </section>
+
+            <section className="rounded-xl border border-zinc-200 bg-white p-5">
+              <p className="text-base font-semibold text-zinc-900">댓글 {post.comments.length}개</p>
+
+              <form onSubmit={handleCreateComment} className="mt-4 flex gap-2">
+                <input
+                  type="text"
+                  value={commentContent}
+                  onChange={(event) => setCommentContent(event.target.value)}
+                  placeholder="댓글을 입력해 주세요."
+                  className="h-10 flex-1 rounded-md border border-zinc-300 px-3 text-sm outline-none focus:border-zinc-500"
+                />
+                <button
+                  type="submit"
+                  disabled={isCommentSubmitting}
+                  className="rounded-md bg-zinc-900 px-4 text-sm font-medium text-white hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isCommentSubmitting ? "작성 중..." : "작성"}
+                </button>
+              </form>
+
+              {post.comments.length === 0 ? (
+                <p className="mt-4 text-sm text-zinc-400">아직 댓글이 없습니다.</p>
+              ) : (
+                <ul className="mt-4 space-y-3">
+                  {post.comments.map((comment) => (
+                    <CommentItem
+                      key={comment.id}
+                      comment={comment}
+                      canManage={canManageComment}
+                      getCommentLikeUi={getCommentLikeUi}
+                      onToggleCommentLike={handleToggleCommentLike}
+                      editingCommentId={editingCommentId}
+                      editingCommentContent={editingCommentContent}
+                      setEditingCommentContent={setEditingCommentContent}
+                      onStartCommentEdit={startEditComment}
+                      onCancelCommentEdit={cancelEditComment}
+                      onSubmitCommentEdit={submitEditComment}
+                      onDeleteComment={handleDeleteComment}
+                    />
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            <div>
+              <Link
+                href={`/boards/${post.boardId}/posts`}
+                className="inline-flex rounded-md border border-zinc-300 px-4 py-2 text-sm text-zinc-700 hover:bg-zinc-100"
+              >
+                목록으로
+              </Link>
+            </div>
+          </>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/frontend/src/app/posts/write/page.tsx
+++ b/frontend/src/app/posts/write/page.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { FormEvent, useEffect, useState } from "react";
+
+type ApiResponse<T> = {
+  success: boolean;
+  code: string | null;
+  message: string | null;
+  data: T;
+};
+
+type Category = {
+  id: number;
+  name: string;
+  boardId: number;
+};
+
+type PostWriteResponse = {
+  id: number;
+};
+
+function getApiBaseUrl() {
+  return process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8080";
+}
+
+export default function PostWritePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const boardId = searchParams.get("boardId")?.trim() ?? "";
+
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [categoryId, setCategoryId] = useState("");
+  const [isLoadingMeta, setIsLoadingMeta] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+
+  useEffect(() => {
+    if (!boardId) {
+      setErrorMessage("게시판 정보가 없습니다. 게시판 목록에서 다시 접근해 주세요.");
+      setIsLoadingMeta(false);
+      return;
+    }
+
+    const fetchCategories = async () => {
+      setIsLoadingMeta(true);
+      setErrorMessage("");
+
+      try {
+        const res = await fetch(`${getApiBaseUrl()}/boards/${boardId}/categories`, {
+          method: "GET",
+          credentials: "include",
+        });
+
+        if (!res.ok) {
+          throw new Error(`카테고리 정보를 불러오지 못했습니다. (${res.status})`);
+        }
+
+        const json = (await res.json()) as ApiResponse<Category[]>;
+
+        if (!json.success) {
+          throw new Error(json.message ?? "카테고리 목록 조회에 실패했습니다.");
+        }
+
+    
+        setCategories(json.data);
+        setCategoryId(json.data.length > 0 ? String(json.data[0].id) : "");
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : "카테고리 조회 중 오류가 발생했습니다.");
+      } finally {
+        setIsLoadingMeta(false);
+      }
+    };
+
+    fetchCategories();
+  }, [boardId]);
+
+  const onSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!title.trim() || !content.trim() || !boardId || !categoryId) {
+      setErrorMessage("제목, 내용, 카테고리를 모두 입력해 주세요.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setErrorMessage("");
+
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/posts`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim(),
+          content: content.trim(),
+          boardId: Number(boardId),
+          categoryId: Number(categoryId),
+        }),
+      });
+
+      if (!res.ok) {
+        if (res.status === 401) throw new Error("로그인이 필요합니다. 로그인 후 다시 시도해 주세요.");
+        throw new Error(`게시글 작성에 실패했습니다. (${res.status})`);
+      }
+
+      const json = (await res.json()) as ApiResponse<PostWriteResponse>;
+
+      if (!json.success) {
+        throw new Error(json.message ?? "게시글 작성에 실패했습니다.");
+      }
+
+      router.push(`/posts/${json.data.id}`);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "알 수 없는 오류가 발생했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-zinc-50 px-6 py-8">
+      <main className="mx-auto w-full max-w-4xl rounded-xl border border-zinc-200 bg-white p-6">
+        <header className="mb-6">
+          <p className="text-sm text-zinc-500">게시글 작성</p>
+          <h1 className="mt-1 text-xl font-semibold text-zinc-900">새 게시글 등록</h1>
+        </header>
+
+        {errorMessage && (
+          <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+            {errorMessage}
+          </div>
+        )}
+
+        <form className="flex flex-col gap-4" onSubmit={onSubmit}>
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-zinc-700">카테고리</span>
+            <select
+              value={categoryId}
+              onChange={(e) => setCategoryId(e.target.value)}
+              disabled={isLoadingMeta || isSubmitting || categories.length === 0}
+              className="h-10 rounded-md border border-zinc-300 px-3 text-sm outline-none focus:border-zinc-500 disabled:bg-zinc-100"
+            >
+              {categories.length === 0 ? (
+                <option value="">선택 가능한 카테고리가 없습니다</option>
+              ) : (
+                categories.map((category) => (
+                  <option key={category.id} value={category.id}>
+                    {category.name}
+                  </option>
+                ))
+              )}
+            </select>
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-zinc-700">제목</span>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              maxLength={100}
+              placeholder="제목을 입력하세요"
+              disabled={isLoadingMeta || isSubmitting}
+              className="h-11 rounded-md border border-zinc-300 px-3 text-sm outline-none focus:border-zinc-500 disabled:bg-zinc-100"
+            />
+          </label>
+
+          <label className="flex flex-col gap-1 text-sm">
+            <span className="font-medium text-zinc-700">내용</span>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="내용을 입력하세요"
+              disabled={isLoadingMeta || isSubmitting}
+              className="min-h-64 rounded-md border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500 disabled:bg-zinc-100"
+            />
+          </label>
+
+          <div className="mt-2 flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => router.back()}
+              disabled={isSubmitting}
+              className="rounded-md border border-zinc-300 px-4 py-2 text-sm text-zinc-700 hover:bg-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              취소
+            </button>
+            <button
+              type="submit"
+              disabled={isLoadingMeta || isSubmitting}
+              className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-semibold text-white hover:bg-zinc-700 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSubmitting ? "등록 중..." : "등록"}
+            </button>
+          </div>
+        </form>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## 📌 과제 설명

- close #91 
- 게시글 관련 프론트엔드 페이지 1차 구현
- 글쓰기 페이지 연동을 위한 백엔드 API 추가

#### 구현한 페이지
- 게시글 목록 페이지 (`/boards/[boardId]/posts`)
- 게시글 상세 페이지 (`/posts/[postId]`)
- 게시글 작성 페이지 (`/posts/write`)

## 👩‍💻 요구 사항과 구현 내용

#### 1. 게시글 목록 페이지 (`/boards/[boardId]/posts`)
- 게시판별 게시글 목록 API 연동 (`GET /boards/{boardId}/posts`)
- 키워드 검색 기능
- 카테고리 필터 기능
- 페이지네이션 (1-based)

#### 2. 게시글 상세 페이지 (`/posts/[postId]`)
- 게시글 상세 API 연동 (`GET /posts/{postId}`)
- 댓글 트리 토글 (펼치기/접기)
- 좋아요 기능
- 작성자 본인에게만 수정/삭제 버튼 노출
- 비로그인 사용자 접근 시 로그인 페이지 안내

#### 3. 게시글 작성 페이지 (`/posts/write`)
- 게시판별 카테고리 드롭다운 연동 (`GET /boards/{boardId}/categories`)
- 게시글 작성 API 연동 (`POST /posts`)
- `boardId`를 query param으로 전달받아 게시판 자동 지정
- 401 응답 시 로그인 필요 안내 메시지 처리
- 작성 완료 후 해당 게시글 상세 페이지로 이동

#### 4. 백엔드 - 게시판별 카테고리 목록 조회 API 추가
- `CategoryRepository`: `findByBoardId` 메서드 추가
- `CategoryService`: `listByBoardId` 메서드 추가
- `BoardController`: `GET /boards/{boardId}/categories` 엔드포인트 추가

## ✅ PR 포인트 & 궁금한 점

- 현재 게시판 목록 페이지가 미구현 상태라, 각 페이지 접근 시 아래 URL로 직접 진입해야 합니다.
  - 게시글 목록: `http://localhost:3000/boards/1/posts`
  - 게시글 작성: `http://localhost:3000/posts/write?boardId=1`
- 게시글 상세 페이지와 게시글 작성 페이지는 **로그인한 사용자만 접근 가능**합니다. 비로그인 상태에서는 로그인 안내 메시지가 표시됩니다.

### 초기 구현 화면(토글 열기)
<details>
<summary>게시글 목록 페이지</summary>

![게시글 목록](https://github.com/user-attachments/assets/a5d10622-5905-4cc1-a81f-993d118e2620)

</details>

<details>
<summary>게시글 상세 페이지</summary>

![게시글 상세](https://github.com/user-attachments/assets/70a56b48-97ff-4073-a86f-3954095d02f6)

</details>

<details>
<summary>게시글 작성 페이지</summary>

![게시글 작성](https://github.com/user-attachments/assets/dc185a54-d848-48c4-a9b1-3017dc0d958f)

</details>
