### PR TITLE
feat : 카테고리별 게시글 목록 페이지에서 인기순 정렬 동작 수정(frontend-post-v4)

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/controller/PostController.java
@@ -55,9 +55,10 @@ public class PostController {
             @PathVariable Long boardId,
             @PathVariable Long categoryId,
             @RequestParam(defaultValue = "1") @Min(1) int page,
-            @RequestParam(required = false) @Size(max = 50) String keyword
+            @RequestParam(required = false) @Size(max = 50) String keyword,
+            @RequestParam(defaultValue = "latest") String sort
     ) {
-        PostPageResponseDto posts = postService.getPostsByBoardAndCategory(boardId, categoryId, page, keyword);
+        PostPageResponseDto posts = postService.getPostsByBoardAndCategory(boardId, categoryId, page, keyword, sort);
         return ResponseEntity.ok(ApiResponse.ofSuccess(posts));
     }
 

--- a/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
+++ b/backend/src/main/java/com/team01/backend/domain/post/service/PostService.java
@@ -208,13 +208,13 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public PostPageResponseDto getPostsByBoardAndCategory(Long boardId, Long categoryId, int page, String keyword) {
+    public PostPageResponseDto getPostsByBoardAndCategory(Long boardId, Long categoryId, int page, String keyword, String sort) {
         validateCategoryInBoard(categoryId, boardId);
         Pageable pageable = toPageable(page);
 
         // categoryId 고정, keyword 검색 포함하여 QueryDSL로 조회
         Page<PostResponseDto> postPage = postRepository
-                .searchByBoardId(boardId, keyword, categoryId, pageable, "latest")
+                .searchByBoardId(boardId, keyword, categoryId, pageable, sort)
                 .map(PostResponseDto::new);
 
         return PostPageResponseDto.from(postPage);

--- a/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
+++ b/backend/src/main/java/com/team01/backend/global/initData/BaseInitData.java
@@ -90,9 +90,9 @@ public class BaseInitData {
         if(boardService.count() > 0){
             return;
         }
-        boardService.createBoard("name1", "description1");
-        boardService.createBoard("name2", "description2");
-        boardService.createBoard("name3", "description3");
+        boardService.createBoard("자유게시판", "취업 준비의 고단함부터 소소한 일상까지, 우리들만의 솔직한 이야기를 나누는 공간입니다.");
+        boardService.createBoard("취업 공고", "꿈을 향한 첫걸음, 최신 채용 공고를 확인하고 당신의 커리어를 시작하세요.");
+        boardService.createBoard("자소서 피드백", "혼자 쓰면 막막한 자기소개서, 합격 선배와 동료들의 꼼꼼한 첨삭으로 완성도를 높여보세요.");
 
         //4번 게시판 삭제
         boardService.createBoard("name4", "description4");

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.8.0",
         "next": "16.2.3",
@@ -70,7 +71,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -455,6 +455,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1565,7 +1574,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1625,7 +1633,6 @@
       "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.1",
         "@typescript-eslint/types": "8.58.1",
@@ -2151,7 +2158,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2438,7 +2444,6 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -2506,7 +2511,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3075,7 +3079,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3261,7 +3264,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5486,7 +5488,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5496,7 +5497,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6188,7 +6188,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6351,7 +6350,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6627,7 +6625,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.8.0",
     "next": "16.2.3",


### PR DESCRIPTION
## 📌 과제 설명

카테고리별 게시글 목록 페이지에서 인기순 정렬이 동작하지 않는 문제를 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용

**fix: 카테고리별 게시글 목록 인기순 정렬 미동작 수정**
- 백엔드 `getPostsByBoardAndCategory()`에 `sort` 파라미터 추가
- `PostController` 카테고리별 조회 엔드포인트에 `sort` 쿼리 파라미터 추가
- 프론트 카테고리별 게시글 목록 페이지에서 API 호출 시 `sort` 파라미터 전달

## ✅ PR 포인트 & 궁금한 점

- 기존 카테고리별 조회 로직에서 `sort`가 `"latest"`로 하드코딩되어 있었는데, 게시판별 목록과 동일하게 파라미터로 받도록 통일했습니다.
