### PR TITLE
feat : 가입일자 수정

### DIFF
--- a/backend/src/main/java/com/team01/backend/domain/user/dto/MyPageResponse.java
+++ b/backend/src/main/java/com/team01/backend/domain/user/dto/MyPageResponse.java
@@ -1,5 +1,6 @@
 package com.team01.backend.domain.user.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
 import java.time.LocalDateTime;
 
@@ -14,6 +15,7 @@ public class MyPageResponse {
     private String email;        // 사용자 계정 아이디
     private String nickname;     // 사용자 활동 닉네임
     private String profileImage; // 사용자 프로필 이미지 경로
-    private String role;         // 사용자 권한 (USER 또는 ADMIN)
+    private String role;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")// 사용자 권한 (USER 또는 ADMIN)
     private LocalDateTime createdAt; // [수정] UserService의 요청을 수용하기 위한 필드 추가
 }

--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -226,7 +226,7 @@ export default function MyPage() {
                   </label>
                   <input
                     readOnly
-                    value={user.joinedAt ?? "—"}
+                    value={user.createdAt ?? "—"}
                     className="w-full cursor-not-allowed rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-sm text-neutral-600"
                   />
                 </div>

--- a/frontend/src/app/mypage/page.tsx
+++ b/frontend/src/app/mypage/page.tsx
@@ -226,7 +226,7 @@ export default function MyPage() {
                   </label>
                   <input
                     readOnly
-                    value={user.createdAt ?? "—"}
+                    value={user.createdAt ? user.createdAt.split(" ")[0] : "—"}
                     className="w-full cursor-not-allowed rounded-xl border border-neutral-200 bg-neutral-50 px-4 py-3 text-sm text-neutral-600"
                   />
                 </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -3,7 +3,7 @@ export type MyPageUser = {
   nickname: string;
   profileImage: string | null;
   role: string;
-  joinedAt?: string | null;
+  createdAt?: string | null;
 };
 
 export type Board = {


### PR DESCRIPTION
## 📌 과제 설명

마이페이지에서 가입일자가 표시되지 않는 문제를 수정했습니다.

## 👩‍💻 요구 사항과 구현 내용

**fix: 마이페이지 가입일자 표시 수정**
- `MyPageResponse`에 `@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")` 추가
- 프론트 `MyPageUser` 타입에서 `joinedAt` → `createdAt`으로 필드명 수정
- 마이페이지에서 `user.createdAt`으로 가입일자 표시
